### PR TITLE
Add support for i386 iOS simulator

### DIFF
--- a/makefile.ios
+++ b/makefile.ios
@@ -47,9 +47,17 @@ $(WICKR_CRYPTO_IOS_REL)/x86_64/lib/libwickr_crypto_lib.a: $(WICKR_CRYPTO_IOS_REL
 
 x86_64: $(WICKR_CRYPTO_IOS_REL)/x86_64/lib/libwickr_crypto_lib.a
 
+#
+$(WICKR_CRYPTO_IOS_REL)/i386/Makefile:
+	$(call cmake_create,i386,Release,SIMULATOR)
 
-release: armv7 arm64 x86_64
+$(WICKR_CRYPTO_IOS_REL)/i386/lib/libwickr_crypto_lib.a: $(WICKR_CRYPTO_IOS_REL)/i386/Makefile
+	$(call cmake_build,i386,Release)
 
+i386: $(WICKR_CRYPTO_IOS_REL)/i386/lib/libwickr_crypto_lib.a
+
+
+release: armv7 arm64 x86_64 i386
 
 armv7.install: $(WICKR_CRYPTO_IOS_REL)/armv7/lib/libwickr_crypto_lib.a
 	$(call cmake_install,armv7,Release)
@@ -59,8 +67,11 @@ arm64.install: $(WICKR_CRYPTO_IOS_REL)/arm64/lib/libwickr_crypto_lib.a
 
 x86_64.install: $(WICKR_CRYPTO_IOS_REL)/x86_64/lib/libwickr_crypto_lib.a
 	$(call cmake_install,x86_64,Release)
+	
+i386.install: $(WICKR_CRYPTO_IOS_REL)/i386/lib/libwickr_crypto_lib.a
+	$(call cmake_install,i386,Release)
 
-install: armv7.install arm64.install x86_64.install
+install: armv7.install arm64.install x86_64.install i386.install
 
 
 #################################################################
@@ -98,8 +109,15 @@ $(WICKR_CRYPTO_IOS_DEB)/x86_64/lib/libwickr_crypto_lib.a: $(WICKR_CRYPTO_IOS_DEB
 
 debug.x86_64: $(WICKR_CRYPTO_IOS_DEB)/x86_64/lib/libwickr_crypto_lib.a
 
+$(WICKR_CRYPTO_IOS_DEB)/i386/Makefile:
+	$(call cmake_create,i386,Debug,SIMULATOR)
 
-debug: debug.armv7 debug.arm64 debug.x86_64
+$(WICKR_CRYPTO_IOS_DEB)/i386/lib/libwickr_crypto_lib.a: $(WICKR_CRYPTO_IOS_DEB)/i386/Makefile
+	$(call cmake_build,i386,Debug)
+
+debug.i386: $(WICKR_CRYPTO_IOS_DEB)/i386/lib/libwickr_crypto_lib.a
+
+debug: debug.armv7 debug.arm64 debug.x86_64 debug.i386
 
 
 debug.armv7.install: $(WICKR_CRYPTO_IOS_DEB)/armv7/lib/libwickr_crypto_lib.a
@@ -110,8 +128,11 @@ debug.arm64.install: $(WICKR_CRYPTO_IOS_DEB)/arm64/lib/libwickr_crypto_lib.a
 
 debug.x86_64.install: $(WICKR_CRYPTO_IOS_DEB)/x86_64/lib/libwickr_crypto_lib.a
 	$(call cmake_install,x86_64,Debug)
+	
+debug.i386.install: $(WICKR_CRYPTO_IOS_DEB)/x86_64/lib/libwickr_crypto_lib.a
+	$(call cmake_install,i386,Debug)
 
-debug.install: debug.armv7.install debug.arm64.install debug.x86_64.install
+debug.install: debug.armv7.install debug.arm64.install debug.x86_64.install debug.i386.install
 
 
 #################################################################

--- a/third-party/bcrypt/crypt_blowfish.c
+++ b/third-party/bcrypt/crypt_blowfish.c
@@ -57,7 +57,7 @@
 #define BF_ASM				0
 #define BF_SCALE			0
 #elif defined(__i386__)
-#define BF_ASM				1
+#define BF_ASM				0
 #define BF_SCALE			1
 #elif defined(__x86_64__) || defined(__alpha__) || defined(__hppa__)
 #define BF_ASM				0

--- a/third-party/openssl-configure-ios.sh
+++ b/third-party/openssl-configure-ios.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 echo PREFIX=$1
-./Configure --prefix=$1 darwin64-x86_64-cc 
+./Configure --prefix=$1 ${CONFIGURE_FOR} 
 sed -ie "s!^CFLAG=!CFLAG=-isysroot ${CROSS_TOP}/SDKs/${CROSS_SDK} !" "Makefile"	
 echo DONE CONFIGURING

--- a/third-party/setenv-ios.sh
+++ b/third-party/setenv-ios.sh
@@ -11,7 +11,11 @@ MINSDKVERSION="8.0"
 if [ "${ARCH}" == "i386" ] || [ "${ARCH}" == "x86_64" ] ;
 then
     export IOS_PLATFORM="iPhoneSimulator"
-    export CONFIGURE_FOR="darwin64-x86_64-cc"
+    if [ "${ARCH}" == "x86_64" ]; then
+      export CONFIGURE_FOR="darwin64-x86_64-cc"
+    else
+      export CONFIGURE_FOR="iphoneos-cross"
+    fi
 else
     export IOS_PLATFORM="iPhoneOS"
     export CONFIGURE_FOR="iphoneos-cross"

--- a/third-party/wickr-openssl.cmake
+++ b/third-party/wickr-openssl.cmake
@@ -80,7 +80,7 @@ elseif(APPLE AND IOS)
             INSTALL_COMMAND   "${PORTS_SCRIPTS}/setenv-ios.sh" ${IOS_ARCH} make install_sw
             BUILD_IN_SOURCE 1
          )
-    elseif(IOS_ARCH MATCHES "x86_64")
+    elseif(IOS_ARCH MATCHES "x86_64" OR IOS_ARCH MATCHES "i386")
         message("openssl: iOS: arch=x86_64")
         set( ENV{IOS_ARCH} ${IOS_ARCH} )
         ExternalProject_add(wickr-openssl


### PR DESCRIPTION
Remove i386 ASM for bcrypt since it is not supported