### PR TITLE
Added Linux support for OpenSSL 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,13 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
+      env:
+      - OPENSSL="1.0.2"
+    - os: linux
+      dist: trusty
+      sudo: required
+      env:
+      - OPENSSL="1.1.0"
     - os: osx
       osx_image: xcode8.2
   exclude:
@@ -15,10 +22,11 @@ matrix:
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository ppa:george-edison55/cmake-3.x -y; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository ppa:0k53d-karl-f830m/openssl -y; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$OPENSSL" == "1.0.2" ]]; then sudo add-apt-repository ppa:0k53d-karl-f830m/openssl -y; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -q; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install openssl -y; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$OPENSSL" == "1.0.2" ]]; then sudo apt-get install openssl -y; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install cmake -y; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$OPENSSL" == "1.1.0" ]]; then git clone https://github.com/openssl/openssl.git; cd openssl; git checkout tags/OpenSSL_1_1_0e; ./config shared no-threads; make; sudo make install; sudo rm /usr/lib/gcc/x86_64-linux-gnu/4.8/../../../x86_64-linux-gnu/libcrypto.a; cd ..; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; brew install cmake; brew install pkgconfig; fi
 
 script:


### PR DESCRIPTION
Resolves #2. Allows building the library on systems that have OpenSSL 1.1.0 installed, while also maintaining compatibility with 1.0.2 and 1.0.1 versions