### PR TITLE
Updated key exchange to support protecting raw bytes

### DIFF
--- a/src/crypto/crypto_engine.h
+++ b/src/crypto/crypto_engine.h
@@ -367,7 +367,7 @@ wickr_digest_t wickr_digest_matching_curve(wickr_ec_curve_t curve);
 
  Get the matching exchange cipher given a message packet cipher
  
- An exchange cipher is used for wrapping / unwrapping packet content decryption key material (see wickr_key_exchange_create_from_components)
+ An exchange cipher is used for wrapping / unwrapping packet content decryption key material (see wickr_key_exchange_create_with_packet_key)
  This function currently always returns CIPHER_ID_AES256_CTR
  The lack of authentication on this layer is a performance / space optimization, since it is ultimately protecting authenticated mode key material (currently always CIPHER_ID_AES256_GCM) to be used for packet content decryption
  If bits are flipped in the key exchange itself, the resulting unauthenticated output will not be able to decrypt the GCM mode packet content

--- a/src/test/test_protocol.c
+++ b/src/test/test_protocol.c
@@ -101,7 +101,7 @@ DESCRIBE(wickr_key_exchange, "protocol: wickr_key_exchange")
     wickr_ec_key_t *exchange_key = engine.wickr_crypto_engine_ec_rand_key(engine.default_curve);
     wickr_node_t *receiver = createUserNode("Bob", engine.wickr_crypto_engine_crypto_random(32));
     
-    keyExchange = wickr_key_exchange_create_from_components(&engine, sender_identity, receiver, exchange_key, pktKey, CURRENT_PACKET_VERSION);
+    keyExchange = wickr_key_exchange_create_with_packet_key(&engine, sender_identity, receiver, exchange_key, pktKey, CURRENT_PACKET_VERSION);
     
     
     IT( "Create Key Exchange From Components should not return NULL")
@@ -118,7 +118,7 @@ DESCRIBE(wickr_key_exchange, "protocol: wickr_key_exchange")
     IT("should work with valid older version exchanges")
     {
         for (uint8_t i = OLDEST_PACKET_VERSION; i <= CURRENT_PACKET_VERSION; i++) {
-            wickr_key_exchange_t *exchange =  wickr_key_exchange_create_from_components(&engine, sender_identity, receiver, exchange_key, pktKey, i);
+            wickr_key_exchange_t *exchange =  wickr_key_exchange_create_with_packet_key(&engine, sender_identity, receiver, exchange_key, pktKey, i);
             
             wickr_cipher_key_t *cipher_key = wickr_key_exchange_derive_packet_key(&engine, sender_identity, receiver, exchange_key, exchange, i);
             
@@ -138,7 +138,7 @@ DESCRIBE(wickr_key_exchange, "protocol: wickr_key_exchange")
     
     IT("should be able to derive a packet key from an existing exchange")
     {
-        keyExchange =  wickr_key_exchange_create_from_components(&engine, sender_identity, receiver, exchange_key, pktKey, CURRENT_PACKET_VERSION);
+        keyExchange =  wickr_key_exchange_create_with_packet_key(&engine, sender_identity, receiver, exchange_key, pktKey, CURRENT_PACKET_VERSION);
 
         wickr_cipher_key_t *cipher_key = wickr_key_exchange_derive_packet_key(&engine, sender_identity, receiver, exchange_key, keyExchange, CURRENT_PACKET_VERSION);
         


### PR DESCRIPTION
Cipher key wrapping is now done by calling raw byte wrapping under the hood