### PR TITLE
Refactor key exchange to use wickr_cipher_result instead of wickr_buffer

### DIFF
--- a/src/wickrcrypto/include/wickrcrypto/key_exchange.h
+++ b/src/wickrcrypto/include/wickrcrypto/key_exchange.h
@@ -39,20 +39,20 @@ extern "C" {
  @struct wickr_key_exchange
  @brief Public key exchange protected data. After a shared secret is generated using a public key with
  identifier 'key_id', and run through a KDF, it is used to encrypt data to be protected by the exchange
- and the ciphertext is stored in 'exchange_data'
+ and the ciphertext is stored in 'exchange_ciphertext'
  @var wickr_key_exchange::exchange_id
  a unique identifier to be assoiciated with the exchange to aid a recipient in finding a particular
  exchange within an exchange set
  @var wickr_key_exchange::key_id the identifier of the recipient's public key was used to compute
- the key protecting 'exchange_data'. This aids a recipient in finding the particular private key they
- need to use to unlock 'exchange_data' upon receipt
- @var wickr_key_exchange::exchange_data
+ the key protecting 'exchange_ciphertext'. This aids a recipient in finding the particular private key they
+ need to use to unlock 'exchange_ciphertext' upon receipt
+ @var wickr_key_exchange::exchange_ciphertext
  ciphered shared secret + KDF protected data
  */
 struct wickr_key_exchange {
     wickr_buffer_t *exchange_id;
     uint64_t key_id;
-    wickr_buffer_t *exchange_data;
+    wickr_cipher_result_t *exchange_ciphertext;
 };
 
 typedef struct wickr_key_exchange wickr_key_exchange_t;
@@ -65,12 +65,12 @@ typedef struct wickr_key_exchange wickr_key_exchange_t;
  
  @param exchange_id see 'wickr_key_exchange' property documentation property documentation
  @param key_id see 'wickr_key_exchange' property documentation property documentation
- @param exchange_data see 'wickr_key_exchange' property documentation property documentation
+ @param exchange_ciphertext see 'wickr_key_exchange' property documentation property documentation
  @return a newly allocated packet metadata set owning the properties passed in
  */
 wickr_key_exchange_t *wickr_key_exchange_create(wickr_buffer_t *exchange_id,
                                                 uint64_t key_id,
-                                                wickr_buffer_t *exchange_data);
+                                                wickr_cipher_result_t *exchange_ciphertext);
     
 
 /**
@@ -156,7 +156,7 @@ void wickr_exchange_array_destroy(wickr_exchange_array_t **array);
 /**
  @ingroup wickr_key_exchange_set
  @struct wickr_key_exchange_set
- @brief A collection of key exchanges for a set of recipients. The data protected inside 'exchange_data'
+ @brief A collection of key exchanges for a set of recipients. The data protected inside 'exchange_ciphertext'
  for each recipient is derived by each recipient node using their individualized key exchange.
  See Wickr white paper 'Prepare Packet Header' section for more information.
  

--- a/src/wickrcrypto/include/wickrcrypto/private/cipher_priv.h
+++ b/src/wickrcrypto/include/wickrcrypto/private/cipher_priv.h
@@ -40,6 +40,16 @@ extern "C" {
  */
 wickr_cipher_key_t *wickr_cipher_key_from_protobytes(ProtobufCBinaryData buffer);
 
+/**
+ 
+ @ingroup wickr_cipher
+ 
+ Create a cipher result from protocol buffers binary data object
+ 
+ @param buffer the protocol buffers binary data object to create the cipher result with
+ @return a cipher result created from serialized bytes within 'buffer' or NULL if parsing buffer fails
+ */
+wickr_cipher_result_t *wickr_cipher_result_from_protobytes(ProtobufCBinaryData buffer);
     
 #ifdef __cplusplus
 }

--- a/src/wickrcrypto/src/cipher.c
+++ b/src/wickrcrypto/src/cipher.c
@@ -15,13 +15,25 @@ const wickr_cipher_t *wickr_cipher_find(uint8_t cipher_id) {
 
 wickr_cipher_result_t *wickr_cipher_result_create(wickr_cipher_t cipher, wickr_buffer_t *iv, wickr_buffer_t *cipher_text, wickr_buffer_t *auth_tag)
 {
-    // We will allow an empty cipher_text for now, this is due to handling of files
-    if (!iv) {
+    /* The IV is required and must be the same length */
+    if (!iv || iv->length != cipher.iv_len) {
+        return NULL;
+    }
+    
+    /* The auth tag is a required field if the cipher is authenticated */
+    if (cipher.is_authenticated && !auth_tag) {
+        return NULL;
+    }
+    
+    /* Make sure auth tag is the correct length */
+    if (auth_tag && auth_tag->length != cipher.auth_tag_len) {
         return NULL;
     }
     
     wickr_cipher_result_t *new_result = wickr_alloc_zero(sizeof(wickr_cipher_result_t));
     new_result->cipher = cipher;
+    
+    
     new_result->iv = iv;
     new_result->cipher_text = cipher_text;
     new_result->auth_tag = auth_tag;

--- a/src/wickrcrypto/src/cipher_priv.c
+++ b/src/wickrcrypto/src/cipher_priv.c
@@ -3,9 +3,20 @@
 
 wickr_cipher_key_t *wickr_cipher_key_from_protobytes(ProtobufCBinaryData buffer)
 {
-    wickr_buffer_t node_key_buffer;
-    node_key_buffer.bytes = buffer.data;
-    node_key_buffer.length = buffer.len;
+    wickr_buffer_t node_key_buffer = {
+        .bytes = buffer.data,
+        .length = buffer.len
+    };
     
     return wickr_cipher_key_from_buffer(&node_key_buffer);
+}
+
+wickr_cipher_result_t *wickr_cipher_result_from_protobytes(ProtobufCBinaryData buffer)
+{
+    wickr_buffer_t cipher_result_buffer = {
+        .bytes = buffer.data,
+        .length = buffer.len
+    };
+    
+    return wickr_cipher_result_from_buffer(&cipher_result_buffer);
 }


### PR DESCRIPTION
* Key exchanges always use wickr_cipher_result, so it has been refactored to use that internally instead of wickr_buffer, to remove the conversion from where it is called

* Internalized sanity checks inside wickr_cipher_result_create that were found outside it