### PR TITLE
Minor fixes for some warnings

### DIFF
--- a/src/wickrcrypto/src/kdf.c
+++ b/src/wickrcrypto/src/kdf.c
@@ -231,7 +231,9 @@ static wickr_buffer_t *__bcrypt_generate_salt(int workfactor, int salt_size)
         return NULL;
     }
     
-    if (!crypt_gensalt_rn("$2y$", workfactor, (const char *)rand_bytes->bytes, rand_bytes->length, (char *)salt_buffer->bytes, salt_buffer->length)) {
+    if (!crypt_gensalt_rn("$2y$", workfactor, (const char *)rand_bytes->bytes,
+                          (unsigned long)rand_bytes->length,
+                          (char *)salt_buffer->bytes, salt_buffer->length)) {
         wickr_buffer_destroy(&rand_bytes);
         wickr_buffer_destroy(&salt_buffer);
         return NULL;

--- a/src/wickrcrypto/src/key_exchange.c
+++ b/src/wickrcrypto/src/key_exchange.c
@@ -251,13 +251,14 @@ void wickr_key_exchange_set_destroy(wickr_key_exchange_set_t **header)
     *header = NULL;
 }
 
-static void __wickr_key_exchange_proto_array_destroy(Wickr__Proto__KeyExchangeSet__Exchange **exchanges, uint32_t num_exchanges)
+static void __wickr_key_exchange_proto_array_destroy(Wickr__Proto__KeyExchangeSet__Exchange **exchanges,
+                                                     size_t num_exchanges)
 {
     if (!exchanges) {
         return;
     }
     
-    for (int i = 0; i < num_exchanges; i++) {
+    for (size_t i = 0; i < num_exchanges; i++) {
         __wickr_key_exchange_proto_free(exchanges[i]);
     }
     

--- a/src/wickrcrypto/src/openssl_suite.c
+++ b/src/wickrcrypto/src/openssl_suite.c
@@ -541,8 +541,8 @@ wickr_buffer_t *openssl_aes256_decrypt(const wickr_cipher_result_t *cipher_resul
     
     /* Update the AAD if needed */
     
-    if (aad) {
-        if (1 != EVP_DecryptUpdate(ctx, NULL, &temp_length, aad->bytes, aad->length)) {
+    if (aad && aad->length <= INT_MAX) {
+        if (1 != EVP_DecryptUpdate(ctx, NULL, &temp_length, aad->bytes, (int)aad->length)) {
             goto process_error;
         }
     }


### PR DESCRIPTION
* Protobuf-c 1.3 wants size_t for array lengths
* Missing cast of salt length to Int before calling bcrypt
* Cast AAD length in AES_GCM to Int, since OpenSSL requires Int for length