### PR TITLE
Added context and identity serialization methods to swig wrappers

### DIFF
--- a/src/wickrcrypto/include/wickrcrypto/wickr_ctx.h
+++ b/src/wickrcrypto/include/wickrcrypto/wickr_ctx.h
@@ -330,7 +330,7 @@ wickr_buffer_t *wickr_ctx_serialize(const wickr_ctx_t *ctx);
  */
 wickr_ctx_t *wickr_ctx_create_from_buffer(const wickr_crypto_engine_t engine,
                                           wickr_dev_info_t *dev_info,
-                                          wickr_buffer_t *buffer);
+                                          const wickr_buffer_t *buffer);
 
 /**
  @ingroup wickr_ctx

--- a/src/wickrcrypto/src/wickr_ctx.c
+++ b/src/wickrcrypto/src/wickr_ctx.c
@@ -575,7 +575,7 @@ wickr_buffer_t *wickr_ctx_serialize(const wickr_ctx_t *ctx)
 
 wickr_ctx_t *wickr_ctx_create_from_buffer(const wickr_crypto_engine_t engine,
                                           wickr_dev_info_t *dev_info,
-                                          wickr_buffer_t *buffer)
+                                          const wickr_buffer_t *buffer)
 {
     if (!dev_info || !buffer) {
         return NULL;

--- a/src/wickrcrypto/swig/identity.i
+++ b/src/wickrcrypto/swig/identity.i
@@ -21,10 +21,14 @@
 %ignore wickr_node_identity_gen;
 %ignore wickr_identity_copy;
 %ignore wickr_identity_destroy;
+%ignore wickr_identity_create_from_buffer;
+%ignore wickr_identity_serialize;
 %ignore wickr_identity_chain_create;
 %ignore wickr_identity_chain_copy;
 %ignore wickr_identity_chain_validate;
 %ignore wickr_identity_chain_destroy;
+%ignore wickr_identity_chain_serialize;
+%ignore wickr_identity_chain_create_from_buffer;
 
 %include "wickrcrypto/identity.h"
 
@@ -37,6 +41,14 @@
  %newobject from_values;
  %newobject sign_data;
  %newobject gen_node;
+ %newobject from_buffer;
+
+ static wickr_identity_t *from_buffer(const wickr_buffer_t *data) {
+     const wickr_crypto_engine_t engine = wickr_crypto_engine_get_default();
+     return wickr_identity_create_from_buffer(data, &engine);
+ }
+
+ wickr_buffer_t *serialize();
 
  wickr_ecdsa_result_t *sign_data(const wickr_buffer_t *data) {
  	wickr_crypto_engine_t engine = wickr_crypto_engine_get_default();
@@ -69,6 +81,14 @@
  }
 
  %newobject from_identities;
+ %newobject from_buffer;
+
+ static wickr_identity_chain_t *from_buffer(const wickr_buffer_t *data) {
+     const wickr_crypto_engine_t engine = wickr_crypto_engine_get_default();
+     return wickr_identity_chain_create_from_buffer(data, &engine);
+ }
+
+ wickr_buffer_t *serialize();
 
  static wickr_identity_chain_t *from_identities(wickr_identity_t *root, wickr_identity_t *node) {
  	wickr_identity_t *root_copy = wickr_identity_copy(root);

--- a/src/wickrcrypto/swig/java/com/wickr/crypto/tests/ContextTests.java
+++ b/src/wickrcrypto/swig/java/com/wickr/crypto/tests/ContextTests.java
@@ -195,4 +195,21 @@ public class ContextTests
 		assertEquals(decoded.getErr(), DecodeError.E_SUCCESS);
 		assertArrayEquals(decoded.getDecryptedPayload().getBody(), message);
 	}
+
+	@Test
+	public void testContextSerialization() {
+
+		//Serialize and deserialize the context
+		byte[] serializedContext = ctx.serialize();
+		assertNotNull(serializedContext);
+		assertTrue(serializedContext.length > 0);
+
+		Context restoredContext = Context.fromBuffer(devinfo, serializedContext);
+		assertNotNull(restoredContext);
+
+		//Test some properties to ensure proper wrapping, this is heavily tested in the wickr-crypto-c library tests
+		assertArrayEquals(restoredContext.getDevInfo().getMsgProtoId(), devinfo.getMsgProtoId());
+		assertArrayEquals(restoredContext.getIdChain().getRoot().getIdentifier(), identifier);
+
+	}
 }

--- a/src/wickrcrypto/swig/java/com/wickr/crypto/tests/IdentityTests.java
+++ b/src/wickrcrypto/swig/java/com/wickr/crypto/tests/IdentityTests.java
@@ -11,29 +11,37 @@ import java.util.*;
 public class IdentityTests
 {
 	protected byte[] identifier;
+	protected ECKey sigKey;
+	protected Identity testIdentity;
 	
 	@Before
     public void setUp() throws UnsupportedEncodingException
     {
         this.identifier = CryptoEngine.digest("wickr".getBytes("UTF8"), null, Digest.sha256());
+        this.sigKey = CryptoEngine.randEcKey(ECCurve.p521());
+        this.testIdentity = Identity.fromValues(IdentityType.IDENTITY_TYPE_ROOT, identifier, sigKey, null);
+    }
+
+    public Identity generateTestNode() {
+
+    	Identity testNode = testIdentity.genNode();
+
+		assertNotNull(testNode);
+		assertEquals(testNode.getType(), IdentityType.IDENTITY_TYPE_NODE);
+		assertNotNull(testNode.getSignature());
+
+		return testNode;
     }
 
     @Test
 	public void testIdentity() throws UnsupportedEncodingException
 	{
-		ECKey sigKey = CryptoEngine.randEcKey(ECCurve.p521());
-
-		//Create an identity from an identifier and a key
-		Identity testIdentity = Identity.fromValues(IdentityType.IDENTITY_TYPE_ROOT, identifier, sigKey, null);
-
+		
 		assertNotNull(testIdentity);
+		assertArrayEquals(testIdentity.getIdentifier(), this.identifier);
 
 		//Generate a random node identity that is signed by testIdentity
-		Identity testNode = testIdentity.genNode();
-
-		assertNotNull(testNode);
-		assertEquals(testNode.getType(), IdentityType.IDENTITY_TYPE_NODE);
-		assertNotNull(testNode.getSignature());
+		Identity testNode = generateTestNode();
 
 		byte[] testSignatureData = "testdata".getBytes("UTF8");
 
@@ -54,6 +62,41 @@ public class IdentityTests
 
 		testChain = IdentityChain.fromIdentities(testIdentity, testNode);
 		assertEquals(testChain.isValid(), false);
+	}
+
+	@Test
+	public void testSerialization() {
+
+		// Serialize and deserialize an identity
+		byte[] serialized = testIdentity.serialize();
+		assertNotNull(serialized);
+		assertTrue(serialized.length > 0);
+
+		Identity restored = Identity.fromBuffer(serialized);
+		assertNotNull(restored);
+
+		//Test some properties to ensure proper wrapping, this is heavily tested in the wickr-crypto-c library tests
+		assertArrayEquals(restored.getIdentifier(), testIdentity.getIdentifier());
+	}
+
+	@Test
+	public void testChainSerialization() {
+
+		// Serialize and deserialize an identity chain
+		Identity testNode = generateTestNode();
+		IdentityChain testChain = IdentityChain.fromIdentities(testIdentity, testNode);
+		assertNotNull(testChain);
+
+		byte[] serialized = testChain.serialize();
+		assertNotNull(serialized);
+		assertTrue(serialized.length > 0);
+
+		IdentityChain restored = IdentityChain.fromBuffer(serialized);
+		assertNotNull(restored);
+
+		//Test some properties to ensure proper wrapping, this is heavily tested in the wickr-crypto-c library tests
+		assertArrayEquals(restored.getRoot().getIdentifier(), testChain.getRoot().getIdentifier());
+		assertArrayEquals(restored.getNode().getIdentifier(), testChain.getNode().getIdentifier());
 	}
 
 }

--- a/src/wickrcrypto/swig/node/test/contextTests.js
+++ b/src/wickrcrypto/swig/node/test/contextTests.js
@@ -180,4 +180,19 @@ describe ("Context Tests", function() {
 
     })
 
+    it("can be serialized and deserialized", function() {
+
+        //Serialize and deserialize the context
+        var serializedContext = ctx.serialize()
+        expect(serializedContext).to.be.a("object")
+
+        var restoredContext = wickrcrypto.Context.fromBuffer(devinfo, serializedContext)
+        expect(restoredContext).to.be.a("object")
+
+        //Test some properties to ensure proper wrapping, this is heavily tested in the wickr-crypto-c library tests
+        expect(restoredContext.devInfo.msgProtoId).to.eql(devinfo.msgProtoId)
+        expect(restoredContext.idChain.root.identifier).to.eql(identifier)
+
+    })
+
 })

--- a/src/wickrcrypto/swig/node/test/identityTests.js
+++ b/src/wickrcrypto/swig/node/test/identityTests.js
@@ -3,25 +3,37 @@
 var expect = require('expect.js')
 var wickrcrypto = require('../../../../../build_node/src/wickrcrypto/swig/node/lib/wickrcrypto')
 
+function generateTestNode(identity) {
+
+    var testNode = identity.genNode()
+
+    expect(testNode).to.be.a("object")
+
+    expect(testNode.type).to.eql(wickrcrypto.IDENTITY_TYPE_NODE)
+    expect(testNode.signature).to.be.a("object")
+
+    return testNode
+}
+
 describe ("Identity Tests", function() {
+
+    var identifier 
+    var sigKey
+    var testIdentity
+
+    beforeEach(function() {
+        identifier = wickrcrypto.CryptoEngine.digest(Buffer.from("wickr"), null, wickrcrypto.Digest.sha256())
+        sigKey = wickrcrypto.CryptoEngine.randEcKey(wickrcrypto.ECCurve.p521())
+        testIdentity = wickrcrypto.Identity.fromValues(wickrcrypto.IDENTITY_TYPE_ROOT, identifier, sigKey, null)
+    })
+
     it ("should be able to create an identity", function() {
 
-        var identifier = wickrcrypto.CryptoEngine.digest(Buffer.from("wickr"), null, wickrcrypto.Digest.sha256())
-
-        var sigKey = wickrcrypto.CryptoEngine.randEcKey(wickrcrypto.ECCurve.p521())
-
         //Create an identity from an identifier and a key
-        var testIdentity = wickrcrypto.Identity.fromValues(wickrcrypto.IDENTITY_TYPE_ROOT, identifier, sigKey, null)
-
         expect(testIdentity).to.be.a("object")
 
         //Generate a random node identity that is signed by testIdentity
-        var testNode = testIdentity.genNode()
-
-        expect(testNode).to.be.a("object")
-
-        expect(testNode.type).to.eql(wickrcrypto.IDENTITY_TYPE_NODE)
-        expect(testNode.signature).to.be.a("object")
+        var testNode = generateTestNode(testIdentity)
 
         var testSignatureData = Buffer.from("testdata")
 
@@ -39,10 +51,41 @@ describe ("Identity Tests", function() {
         expect(testChain.isValid()).to.eql(true)
 
         var sigKey = wickrcrypto.CryptoEngine.randEcKey(wickrcrypto.ECCurve.p521())
-        var testIdentity = wickrcrypto.Identity.fromValues(wickrcrypto.IDENTITY_TYPE_ROOT, identifier, sigKey, null)
+        testIdentity = wickrcrypto.Identity.fromValues(wickrcrypto.IDENTITY_TYPE_ROOT, identifier, sigKey, null)
 
         var testChain = wickrcrypto.IdentityChain.fromIdentities(testIdentity, testNode)
         expect(testChain.isValid()).to.eql(false)
+    })
+
+    it("should be able to serialize an identity", function() {
+
+        // Serialize and deserialize an identity
+        var serialized = testIdentity.serialize()
+        expect(serialized).to.be.a("object")
+
+        var restored = wickrcrypto.Identity.fromBuffer(serialized)
+        expect(restored).to.be.a("object")
+
+        //Test some properties to ensure proper wrapping, this is heavily tested in the wickr-crypto-c library tests
+        expect(restored.identifier).to.eql(testIdentity.identifier)
+    })
+
+    it("should be able to serialize an identity chain", function() {
+
+        // Serialize and deserialize an identity chain
+        var testNode = generateTestNode(testIdentity)
+        var testChain = wickrcrypto.IdentityChain.fromIdentities(testIdentity, testNode)
+        expect(testChain).to.be.a("object")
+
+        var serialized = testChain.serialize()
+        expect(serialized).to.be.a("object")
+
+        var restored = wickrcrypto.IdentityChain.fromBuffer(serialized)
+        expect(restored).to.be.a("object")
+
+        //Test some properties to ensure proper wrapping, this is heavily tested in the wickr-crypto-c library tests
+        expect(restored.root.identifier).to.eql(testChain.root.identifier)
+        expect(restored.node.identifier).to.eql(testChain.node.identifier)
     })
 
 })

--- a/src/wickrcrypto/swig/wickr_ctx.i
+++ b/src/wickrcrypto/swig/wickr_ctx.i
@@ -46,6 +46,8 @@
 %ignore wickr_ctx_parse_packet;
 %ignore wickr_ctx_parse_packet_no_decode;
 %ignore wickr_ctx_decode_packet;
+%ignore wickr_ctx_serialize;
+%ignore wickr_ctx_create_from_buffer;
 %ignore wickr_packet_meta_create;
 %ignore wickr_packet_meta_copy;
 %ignore wickr_packet_meta_destroy;
@@ -159,6 +161,7 @@
     %newobject parse_packet_no_decode;
     %newobject parse_packet;
     %newobject decode_packet;
+    %newobject from_buffer;
 
 	wickr_buffer_t *export_storage_keys(const wickr_buffer_t *passphrase);
 
@@ -166,6 +169,18 @@
 		const wickr_crypto_engine_t engine = wickr_crypto_engine_get_default();
 		return wickr_ctx_import_storage_keys(engine, exported, passphrase);
 	}
+
+    static wickr_ctx_t *from_buffer(wickr_dev_info_t *dev_info, const wickr_buffer_t *buffer) {
+        const wickr_crypto_engine_t engine = wickr_crypto_engine_get_default();
+        wickr_dev_info_t *dev_info_copy = wickr_dev_info_copy(dev_info);
+        wickr_ctx_t *ctx = wickr_ctx_create_from_buffer(engine, dev_info_copy, buffer);
+        if (!ctx) {
+            wickr_dev_info_destroy(&dev_info_copy);
+        }
+        return ctx;
+    }
+
+    wickr_buffer_t *serialize();
 
 #if defined(SWIGPHP)
 	%newobject from_ctx;


### PR DESCRIPTION
* wickr_ctx_serialize and wickr_ctx_create_from_buffer are supported in node and java via wrappers
* wickr_identity_serialize, wickr_identity_chain_serialize, wickr_identity_create_from_buffer, and wickr_identity_chain_create_from_buffer are supported in node and java via wrappers

Closes #77 