### PR TITLE
Refactored Node build to install into a “node” directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ install_manifest.txt
 CTestTestfile.cmake
 .DS_Store
 build*/
+node/
 node_modules/
 pod_deploy/

--- a/node_install.sh
+++ b/node_install.sh
@@ -1,4 +1,5 @@
-mkdir build_node
-cd build_node
-cmake -DBUILD_NODE=ON -DCMAKE_POSITION_INDEPENDENT_CODE=true -DCMAKE_BUILD_TYPE=Release ../
+mkdir -p node/build
+cd node/build
+cmake -DBUILD_NODE=ON -DCMAKE_POSITION_INDEPENDENT_CODE=true -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../ ../../ 
 make
+make install

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
     },
     "description": "A node.js wrapper around the wickr-crypto-c library",
     "version": "1.9.2",
-    "main": "build_node/src/wickrcrypto/swig/node/wickrcrypto.node",
+    "main": "node/lib/wickrcrypto.node",
     "scripts": {
         "install": "node-pre-gyp --target_platform=$(uname -r) install 2> /dev/null || ./node_install.sh",
         "test": "./node_modules/.bin/mocha src/wickrcrypto/swig/node/test"
     },
     "binary": {
         "module_name": "wickrcrypto",
-        "module_path": "./build_node/src/wickrcrypto/swig/node/lib",
+        "module_path": "./node/lib",
         "host": "https://wickr-crypto-c.s3.amazonaws.com/wickr-crypto-c"
     },
     "engines": {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
         "test": "./node_modules/.bin/mocha src/wickrcrypto/swig/node/test"
     },
     "binary": {
-        "module_name": "wickrcrypto",
-        "module_path": "./node/lib",
+        "module_name": "lib/wickrcrypto",
+        "module_path": "./node",
         "host": "https://wickr-crypto-c.s3.amazonaws.com/wickr-crypto-c"
     },
     "engines": {

--- a/src/wickrcrypto/swig/CMakeLists.txt
+++ b/src/wickrcrypto/swig/CMakeLists.txt
@@ -20,3 +20,7 @@ endif()
 if(BUILD_JAVA)
     add_subdirectory(java)
 endif()
+
+# Install the SWIG files so dependencies can utilize them
+file(GLOB SwigFiles *.i)
+install(FILES ${SwigFiles} DESTINATION share/wickrcrypto/swig)

--- a/src/wickrcrypto/swig/java/CMakeLists.txt
+++ b/src/wickrcrypto/swig/java/CMakeLists.txt
@@ -103,6 +103,7 @@ if (ANDROID)
 else ()
     install(FILES ${JAVA_SOURCES} DESTINATION ${CMAKE_INSTALL_PREFIX}/java)
     install(FILES $<TARGET_FILE:wickrcryptoswig> DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    install(FILES ${_jarFile} DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif ()
 
 if (BUILD_TESTS)

--- a/src/wickrcrypto/swig/node/CMakeLists.txt
+++ b/src/wickrcrypto/swig/node/CMakeLists.txt
@@ -30,3 +30,5 @@ if (BUILD_TESTS)
     )
     
 endif ()
+
+install(FILES $<TARGET_FILE:wickrcryptoswig> DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/wickrcrypto/swig/node/test/contextTests.js
+++ b/src/wickrcrypto/swig/node/test/contextTests.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var expect = require('expect.js')
-var wickrcrypto = require('../../../../../build_node/src/wickrcrypto/swig/node/lib/wickrcrypto')
+var wickrcrypto = require('../../../../../node/lib/wickrcrypto')
 
 describe ("Context Tests", function() {
     

--- a/src/wickrcrypto/swig/node/test/cryptoEngineTests.js
+++ b/src/wickrcrypto/swig/node/test/cryptoEngineTests.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var expect = require('expect.js')
-var wickrcrypto = require('../../../../../build_node/src/wickrcrypto/swig/node/lib/wickrcrypto')
+var wickrcrypto = require('../../../../../node/lib/wickrcrypto')
 
 describe("Wickr Crypto Engine", function() {
 

--- a/src/wickrcrypto/swig/node/test/deviceInfoTests.js
+++ b/src/wickrcrypto/swig/node/test/deviceInfoTests.js
@@ -2,7 +2,7 @@
 'use strict'
 
 var expect = require('expect.js')
-var wickrcrypto = require('../../../../../build_node/src/wickrcrypto/swig/node/lib/wickrcrypto')
+var wickrcrypto = require('../../../../../node/lib/wickrcrypto')
 
 describe ("Device Info Tests", function() {
     it ("should be able to create device info", function() {

--- a/src/wickrcrypto/swig/node/test/ecdhCipherTests.js
+++ b/src/wickrcrypto/swig/node/test/ecdhCipherTests.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var expect = require('expect.js')
-var wickrcrypto = require('../../../../../build_node/src/wickrcrypto/swig/node/lib/wickrcrypto')
+var wickrcrypto = require('../../../../../node/lib/wickrcrypto')
 
 describe ("ECDH Cipher Tests", function() {
 

--- a/src/wickrcrypto/swig/node/test/identityTests.js
+++ b/src/wickrcrypto/swig/node/test/identityTests.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var expect = require('expect.js')
-var wickrcrypto = require('../../../../../build_node/src/wickrcrypto/swig/node/lib/wickrcrypto')
+var wickrcrypto = require('../../../../../node/lib/wickrcrypto')
 
 function generateTestNode(identity) {
 

--- a/src/wickrcrypto/swig/node/test/nodeTests.js
+++ b/src/wickrcrypto/swig/node/test/nodeTests.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var expect = require('expect.js')
-var wickrcrypto = require('../../../../../build_node/src/wickrcrypto/swig/node/lib/wickrcrypto')
+var wickrcrypto = require('../../../../../node/lib/wickrcrypto')
 
 describe ("Node Tests", function() {
     it ("should be able to create a node", function() {

--- a/src/wickrcrypto/swig/node/test/rootKeyTests.js
+++ b/src/wickrcrypto/swig/node/test/rootKeyTests.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var expect = require('expect.js')
-var wickrcrypto = require('../../../../../build_node/src/wickrcrypto/swig/node/lib/wickrcrypto')
+var wickrcrypto = require('../../../../../node/lib/wickrcrypto')
 
 describe ("Root Keys Tests", function() {
     it ("should be able to create root keys", function() {

--- a/src/wickrcrypto/swig/node/test/storageKeyTests.js
+++ b/src/wickrcrypto/swig/node/test/storageKeyTests.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var expect = require('expect.js')
-var wickrcrypto = require('../../../../../build_node/src/wickrcrypto/swig/node/lib/wickrcrypto')
+var wickrcrypto = require('../../../../../node/lib/wickrcrypto')
 
 describe ("Storage Keys Tests", function() {
     it ("should be able to create storage keys", function() {


### PR DESCRIPTION
Node build will make install into a node directory instead of just calling "make". This way, dependencies will have a less complex / higher stability path to utilize build output from

Closes #78 