### PR TITLE
Support for key / identity fingerprints

### DIFF
--- a/src/wickrcrypto/include/wickrcrypto/b32.h
+++ b/src/wickrcrypto/include/wickrcrypto/b32.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2012-2018 Wickr Inc.  All rights reserved.
+ *
+ * This code is being released for EDUCATIONAL, ACADEMIC, AND CODE REVIEW PURPOSES
+ * ONLY.  COMMERCIAL USE OF THE CODE IS EXPRESSLY PROHIBITED.  For additional details,
+ * please see LICENSE
+ *
+ * THE CODE IS MADE AVAILABLE "AS-IS" AND WITHOUT ANY EXPRESS OR
+ * IMPLIED GUARANTEES AS TO FITNESS, MERCHANTABILITY, NON-
+ * INFRINGEMENT OR OTHERWISE. IT IS NOT BEING PROVIDED IN TRADE BUT ON
+ * A VOLUNTARY BASIS ON BEHALF OF THE AUTHOR’S PART FOR THE BENEFIT
+ * OF THE LICENSEE AND IS NOT MADE AVAILABLE FOR CONSUMER USE OR ANY
+ * OTHER USE OUTSIDE THE TERMS OF THIS LICENSE. ANYONE ACCESSING THE
+ * CODE SHOULD HAVE THE REQUISITE EXPERTISE TO SECURE THEIR SYSTEM
+ * AND DEVICES AND TO ACCESS AND USE THE CODE FOR REVIEW PURPOSES
+ * ONLY. LICENSEE BEARS THE RISK OF ACCESSING AND USING THE CODE. IN
+ * PARTICULAR, AUTHOR BEARS NO LIABILITY FOR ANY INTERFERENCE WITH OR
+ * ADVERSE EFFECT THAT MAY OCCUR AS A RESULT OF THE LICENSEE
+ * ACCESSING AND/OR USING THE CODE ON LICENSEE’S SYSTEM.
+ */
+
+#ifndef b32_h
+#define b32_h
+
+#include "buffer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+    
+/**
+ @addtogroup base32 base32
+ */
+
+/**
+ 
+ @ingroup base32
+ 
+ Encode data in base32 (Crockford's) encoding
+ 
+ @param buffer the buffer to encode in base32 format
+ @return a buffer representing 'buffer' in base32 format. The length field will represent the string length
+ even though the contents are null terminated
+ */
+wickr_buffer_t *base32_encode(const wickr_buffer_t *buffer);
+    
+/**
+ 
+ @ingroup base32
+ 
+ Decode base32 data to a binary representation
+ 
+ @param a buffer containing a base32 string
+ @return decoded binary data representation of 'buffer' or NULL if 'buffer' contains invalid base32 data
+ */
+wickr_buffer_t *base32_decode(const wickr_buffer_t *buffer);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* b32_h */

--- a/src/wickrcrypto/include/wickrcrypto/fingerprint.h
+++ b/src/wickrcrypto/include/wickrcrypto/fingerprint.h
@@ -1,0 +1,180 @@
+/*
+ * Copyright © 2012-2018 Wickr Inc.  All rights reserved.
+ *
+ * This code is being released for EDUCATIONAL, ACADEMIC, AND CODE REVIEW PURPOSES
+ * ONLY.  COMMERCIAL USE OF THE CODE IS EXPRESSLY PROHIBITED.  For additional details,
+ * please see LICENSE
+ *
+ * THE CODE IS MADE AVAILABLE "AS-IS" AND WITHOUT ANY EXPRESS OR
+ * IMPLIED GUARANTEES AS TO FITNESS, MERCHANTABILITY, NON-
+ * INFRINGEMENT OR OTHERWISE. IT IS NOT BEING PROVIDED IN TRADE BUT ON
+ * A VOLUNTARY BASIS ON BEHALF OF THE AUTHOR’S PART FOR THE BENEFIT
+ * OF THE LICENSEE AND IS NOT MADE AVAILABLE FOR CONSUMER USE OR ANY
+ * OTHER USE OUTSIDE THE TERMS OF THIS LICENSE. ANYONE ACCESSING THE
+ * CODE SHOULD HAVE THE REQUISITE EXPERTISE TO SECURE THEIR SYSTEM
+ * AND DEVICES AND TO ACCESS AND USE THE CODE FOR REVIEW PURPOSES
+ * ONLY. LICENSEE BEARS THE RISK OF ACCESSING AND USING THE CODE. IN
+ * PARTICULAR, AUTHOR BEARS NO LIABILITY FOR ANY INTERFERENCE WITH OR
+ * ADVERSE EFFECT THAT MAY OCCUR AS A RESULT OF THE LICENSEE
+ * ACCESSING AND/OR USING THE CODE ON LICENSEE’S SYSTEM.
+ */
+
+#ifndef fingerprint_h
+#define fingerprint_h
+
+#include "buffer.h"
+#include "eckey.h"
+#include "crypto_engine.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ @addtogroup wickr_fingerprint wickr_fingerprint
+ */
+    
+/**
+ 
+ @ingroup wickr_fingerprint
+ 
+ Fingerprint output format
+ 
+ SHORT - Output a fingerprint that is 1/2 length of the full representation
+ LONG - Output a fingerprint that is encoded to be full length
+ 
+ */
+typedef enum {
+    FINGERPRINT_OUTPUT_SHORT,
+    FINGERPRINT_OUTPUT_LONG
+} wickr_fingerprint_output;
+
+/**
+ 
+ @ingroup wickr_fingerprint
+ 
+ @struct wickr_fingerprint
+ 
+ @brief A fingerprint representation of a combination of signature keys / identifiers
+ @var wickr_fingerprint::data
+ a raw data representation of the fingerprint
+
+ */
+struct wickr_fingerprint {
+    wickr_buffer_t *data;
+};
+
+typedef struct wickr_fingerprint wickr_fingerprint_t;
+
+/**
+ 
+ @ingroup wickr_fingerprint
+ 
+ Fingerprint Encoding Type
+ 
+ SHA512 - Calculated by taking a SHA512 of the inputs concatenated together
+ 
+ */
+typedef enum { WICKR_FINGERPRINT_TYPE_SHA512 } wickr_fingerprint_type;
+
+
+/**
+ 
+ @ingroup wickr_fingerprint
+ 
+ Generate a fingerprint based on a signing key / fixed user identifier
+
+ @param engine the crypto engine to use for underlying hash operations
+ @param key the key to include in the resulting fingerprint
+ @param identifier a fixed user identifier to use in the resulting fingerprint
+ @param type the type of fingerprint algorithm to use when processing key/identifier
+ @return A unique fingerprint representing the combination of key/identifier
+ */
+wickr_fingerprint_t *wickr_fingerprint_gen(wickr_crypto_engine_t engine,
+                                           const wickr_ec_key_t *key,
+                                           const wickr_buffer_t *identifier,
+                                           wickr_fingerprint_type type);
+
+/**
+ 
+ @ingroup wickr_fingerprint
+ 
+ Generate a bilateral fingerprint by combining two existing fingerprints made with 'wickr_fingerprint_gen'.
+ Fingerprints created by this function are identical if local/remote input values are swapped, as they are sorted
+ internally before computation begins
+
+ @param engine the crypto engine to use for underlying hash operations
+ @param local the first existing fingerprint to include in the bilateral fingerprint
+ @param remote the second existing fingerprint to include in the bilateral fingerprint
+ @param type the type of fingerprint algorithm to use when processing local/remote
+ @return A unique fingerprint representing the combination of local/remote
+ */
+wickr_fingerprint_t *wickr_fingerprint_gen_bilateral(wickr_crypto_engine_t engine,
+                                                     const wickr_fingerprint_t *local,
+                                                     const wickr_fingerprint_t *remote,
+                                                     wickr_fingerprint_type type);
+
+/**
+ 
+ @ingroup wickr_fingerprint
+ 
+ Create a new wickr_fingerprint struct
+
+ @param data see 'wickr_fingerprint' property documentation
+ @return a newly allocated fingerprint that takes ownership of the passed inputs
+ */
+wickr_fingerprint_t *wickr_fingerprint_create(wickr_buffer_t *data);
+
+    
+/**
+ 
+ @ingroup wickr_fingerprint
+ 
+ Copy a wickr_fingerprint
+
+ @param fingerprint the fingerprint to copy
+ @return a copy of 'fingerprint' that contains a deep copy of 'data'
+ */
+wickr_fingerprint_t *wickr_fingerprint_copy(const wickr_fingerprint_t *fingerprint);
+    
+
+/**
+ 
+ @ingroup wickr_fingerprint
+ 
+ Destroy a wickr_fingerprint
+
+ @param fingerprint the fingerprint to destroy
+ */
+void wickr_fingerprint_destroy(wickr_fingerprint_t **fingerprint);
+
+/**
+ 
+ @ingroup wickr_fingerprint
+ 
+ Get a base32 representation of a fingerprint
+
+ @param fingerprint the fingerprint to get the base32 representation of
+ @param output_mode the output mode of the base32 representation (short/long)
+ @return A string buffer containing a base32 representation of 'fingerprint' that is null terminatied
+ */
+wickr_buffer_t *wickr_fingerprint_get_b32(const wickr_fingerprint_t *fingerprint, wickr_fingerprint_output output_mode);
+    
+    
+/**
+ 
+ @ingroup wickr_fingerprint
+ 
+ Get a hex representation of a fingerprint
+
+ @param fingerprint the fingerprint to get the hex representation of
+ @param output_mode the output mode of the base32 representation (short/long)
+ @return A string buffer containing a hex representation of 'fingerprint' that is null terminatied
+ */
+wickr_buffer_t *wickr_fingerprint_get_hex(const wickr_fingerprint_t *fingerprint, wickr_fingerprint_output output_mode);
+
+#ifdef __cplusplus
+}
+#endif
+    
+#endif /* fingerprint_h */

--- a/src/wickrcrypto/include/wickrcrypto/identity.h
+++ b/src/wickrcrypto/include/wickrcrypto/identity.h
@@ -28,6 +28,7 @@
 #include "ecdsa.h"
 #include "crypto_engine.h"
 #include "root_keys.h"
+#include "fingerprint.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -184,6 +185,8 @@ void wickr_identity_destroy(wickr_identity_t **identity);
  @return a buffer containing a serialized representation of 'identity' or null if serialization fails
  */
 wickr_buffer_t *wickr_identity_serialize(const wickr_identity_t *identity);
+    
+
 
 /**
  
@@ -196,6 +199,37 @@ wickr_buffer_t *wickr_identity_serialize(const wickr_identity_t *identity);
  @return deserialized identity or null if the deserialization fails
  */
 wickr_identity_t *wickr_identity_create_from_buffer(const wickr_buffer_t *buffer, const wickr_crypto_engine_t *engine);
+
+/**
+ 
+ @ingroup wickr_identity
+ 
+ A unique fingerprint representing the identifier and public signing key of this identity. See 'fingerprint.h'
+ 
+ @param identity the identity to get a unique fingerprint of
+ @param engine the crypto engine to use for underlying hash operations
+ @return a unique fingerprint currently calculated as SHA512(identifier || sig_pub->pub_data)
+ */
+wickr_fingerprint_t *wickr_identity_get_fingerprint(const wickr_identity_t *identity,
+                                                    wickr_crypto_engine_t engine);
+
+
+/**
+ 
+ @ingroup wickr_identity
+ 
+ A fingerprint that is unique between identity and remote_identity
+ 
+ @param identity the identity to get a bilateral fingerprint of
+ @param remote_identity the other party included in the fingerprint
+ @param engine engine the crypto engine to use for underlying hash operations
+ @return a bilateral fingerprint of (identity,remote_identity) or (remote_identity,identity)
+ calculated using SHA512(fingerprint(identity) || fingerprint(remote_identity)).
+*/
+ 
+wickr_fingerprint_t *wickr_identity_get_bilateral_fingerprint(const wickr_identity_t *identity,
+                                                              const wickr_identity_t *remote_identity,
+                                                              wickr_crypto_engine_t engine);
     
 /**
  

--- a/src/wickrcrypto/src/b32.c
+++ b/src/wickrcrypto/src/b32.c
@@ -1,0 +1,282 @@
+
+#include "b32.h"
+#include <string.h>
+
+/* Base32 alphabet (Crockford's Base32) */
+const char alphabet[] = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+/* Calculates the encoded output buffer length for given buffer size (bytes) */
+static size_t __base32_encode_length(size_t bytes)
+{
+    if (bytes >= SIZE_MAX / 8) {
+        return 0;
+    }
+    
+    size_t bits = bytes * 8;
+    size_t length = bits / 5;
+    
+    if ((bits % 5) > 0) {
+        length++;
+    }
+    
+    return length;
+}
+
+/* Calculates the decoded output buffer length for given encode base32 buffer size (bytes) */
+static size_t __base32_decode_length(size_t bytes)
+{
+    if (bytes >= SIZE_MAX / 5) {
+        return 0;
+    }
+    
+    size_t bits = bytes * 5;
+    size_t length = bits / 8;
+    
+    return length;
+}
+
+/* Maps a base32 encoded buffer TO a specified alphabet (i.e. "0123456789ABCDEFGHJKMNPQRSTVWXYZ").
+ Performs in place mapping. */
+static bool __base32_encode_map(unsigned char *inout32, size_t inout32_len, const char *alpha32)
+{
+    // Validate
+    if ((inout32 == 0) || (alpha32 == 0)) {
+        return false;
+    }
+    
+    for (int i = 0; i < inout32_len; i++) {
+        
+        if (inout32[i] >= 32) {
+            return false;
+        }
+        
+        inout32[i] = alpha32[inout32[i]];
+    }
+    
+    return true;
+}
+
+static void __base32_decode_reverse_map(const char* in_alpha32, unsigned char* out_map)
+{
+    /* Set 255 as an out of range marker to easily detect mapping failures */
+    memset(out_map, 255, sizeof(unsigned char) * 256);
+    
+    for (int i = 0; i < 32; i++) {
+        out_map[(int)in_alpha32[i]] = i;
+    }
+}
+
+/* Maps a base32 encoded buffer FROM a specified alphabet (i.e. "0123456789ABCDEFGHJKMNPQRSTVWXYZ").
+   Performs in place mapping. */
+static bool __base32_decode_unmap(unsigned char* inout32, size_t inout32_len, const char* alpha32)
+{
+    if ((inout32 == 0) || (alpha32 == 0)) {
+        return false;
+    }
+    
+    unsigned char rmap[256];
+    __base32_decode_reverse_map(alpha32, rmap);
+    
+    for (size_t i = 0; i < inout32_len; i++) {
+        /* Fail if the character can't be mapped to the proper alphabet */
+        unsigned char mapped_char = rmap[(int)inout32[i]];
+        if ((int)mapped_char == 255) {
+            return NULL;
+        }
+        inout32[i] = mapped_char;
+    }
+    
+    return true;
+}
+
+static bool __base32_encode_block(const unsigned char* in5, unsigned char* out8)
+{
+    // pack 5 bytes
+    uint64_t buffer = 0;
+    
+    for (int i = 0; i < 5; i++) {
+        
+        if (i != 0) {
+            buffer = (buffer << 8);
+        }
+        
+        buffer = buffer | in5[i];
+    }
+    
+    // output 8 bytes
+    for (int j = 7; j >= 0; j--) {
+        
+        buffer = buffer << (24 + (7 - j) * 5);
+        buffer = buffer >> (24 + (7 - j) * 5);
+        
+        unsigned char c = (unsigned char)(buffer >> (j * 5));
+        
+        // self check
+        if (c >= 32) {
+            return false;
+        }
+        
+        out8[7 - j] = c;
+    }
+    
+    return true;
+}
+
+static bool __base32_decode_block(const unsigned char* in8, unsigned char* out5)
+{
+    // pack 8 bytes
+    uint64_t buffer = 0;
+    
+    for (int i = 0; i < 8; i++) {
+        
+        // input check
+        if (in8[i] >= 32) {
+            return false;
+        }
+        
+        if (i != 0) {
+            buffer = (buffer << 5);
+        }
+        
+        buffer = buffer | in8[i];
+    }
+    
+    // output 5 bytes
+    for (int j = 4; j >= 0; j--) {
+        out5[4 - j] = (unsigned char)(buffer >> (j * 8));
+    }
+    
+    return true;
+}
+
+/* Encode given input buffer, and outputs it into given output buffer */
+static bool __base32_encode_base32(const unsigned char *in, size_t in_len, unsigned char *out)
+{
+    if ((in == 0) || (out == 0)) {
+        return false;
+    }
+    
+    size_t d = in_len / 5;
+    size_t r = in_len % 5;
+    
+    unsigned char out_buff[8];
+    
+    for (size_t j = 0; j < d; j++)
+    {
+        if(!__base32_encode_block(&in[j * 5], &out_buff[0])) {
+            return false;
+        }
+        
+        memmove(&out[j * 8], &out_buff[0], sizeof(unsigned char) * 8);
+    }
+    
+    unsigned char padd[5];
+    memset(padd, 0, sizeof(unsigned char) * 5);
+    
+    for (size_t i = 0; i < r; i++) {
+        padd[i] = in[in_len - r + i];
+    }
+    
+    if (!__base32_encode_block(&padd[0], &out_buff[0])) {
+        return false;
+    }
+    
+    memmove(&out[d * 8], &out_buff[0], sizeof(unsigned char) * __base32_encode_length(r));
+    
+    return true;
+}
+
+static bool __base32_decode_base32(const unsigned char* in, size_t in_len, unsigned char* out)
+{
+    if ((in == 0) || (out == 0)) {
+        return false;
+    }
+    
+    size_t d = in_len / 8;
+    size_t r = in_len % 8;
+    
+    unsigned char out_buff[5];
+    
+    for (size_t j = 0; j < d; j++) {
+        if (!__base32_decode_block(&in[j * 8], &out_buff[0])) {
+            return false;
+        }
+        memmove(&out[j * 5], &out_buff[0], sizeof(unsigned char) * 5);
+    }
+    
+    unsigned char padd[8];
+    memset(padd, 0, sizeof(unsigned char) * 8);
+    
+    for (size_t i = 0; i < r; i++) {
+        padd[i] = in[in_len - r + i];
+    }
+    
+    if(!__base32_decode_block(&padd[0], &out_buff[0])) {
+        return false;
+    }
+    
+    memmove(&out[d * 5], &out_buff[0], sizeof(unsigned char) * __base32_decode_length(r));
+    
+    return true;
+}
+
+wickr_buffer_t *base32_encode(const wickr_buffer_t *buffer)
+{
+    if (!buffer) {
+        return NULL;
+    }
+    
+    wickr_buffer_t *return_buffer = wickr_buffer_create_empty_zero(__base32_encode_length(buffer->length));
+    
+    if (!return_buffer) {
+        return NULL;
+    }
+    
+    if (!__base32_encode_base32(buffer->bytes, buffer->length, return_buffer->bytes)) {
+        wickr_buffer_destroy(&return_buffer);
+        return NULL;
+    }
+    
+    if (!__base32_encode_map(return_buffer->bytes, return_buffer->length, alphabet)) {
+        wickr_buffer_destroy(&return_buffer);
+        return NULL;
+    }
+    
+    return return_buffer;
+    
+}
+
+wickr_buffer_t *base32_decode(const wickr_buffer_t *buffer)
+{
+    if (!buffer) {
+        return NULL;
+    }
+    
+    wickr_buffer_t *unmapped = wickr_buffer_copy(buffer);
+    
+    if (!unmapped) {
+        return NULL;
+    }
+    
+    if (!__base32_decode_unmap(unmapped->bytes, unmapped->length, alphabet)) {
+        wickr_buffer_destroy(&unmapped);
+        return NULL;
+    }
+    
+    wickr_buffer_t *decoded = wickr_buffer_create_empty_zero(__base32_decode_length(unmapped->length) + 1);
+    decoded->length = decoded->length - 1;
+    
+    if (!decoded) {
+        return NULL;
+    }
+    
+    if (!__base32_decode_base32(unmapped->bytes, unmapped->length, decoded->bytes)) {
+        wickr_buffer_destroy(&decoded);
+        wickr_buffer_destroy(&unmapped);
+        return NULL;
+    }
+    
+    wickr_buffer_destroy(&unmapped);
+    
+    return decoded;
+}

--- a/src/wickrcrypto/src/fingerprint.c
+++ b/src/wickrcrypto/src/fingerprint.c
@@ -1,0 +1,191 @@
+
+#include "fingerprint.h"
+#include "memory.h"
+#include "util.h"
+#include "b32.h"
+
+static wickr_fingerprint_t *__wickr_fingerprint_sha512_create(wickr_crypto_engine_t engine,
+                                                              wickr_buffer_t *input_data)
+{
+    if (!input_data) {
+        return NULL;
+    }
+    
+    wickr_buffer_t *fingerprint_data = engine.wickr_crypto_engine_digest(input_data, NULL, DIGEST_SHA_512);
+    
+    if (!fingerprint_data) {
+        return NULL;
+    }
+    
+    wickr_fingerprint_t *fingerprint = wickr_fingerprint_create(fingerprint_data);
+    
+    if (!fingerprint) {
+        wickr_buffer_destroy(&fingerprint_data);
+    }
+    
+    return fingerprint;
+}
+
+static wickr_fingerprint_t *__wickr_fingerprint_sha512_encode(wickr_crypto_engine_t engine,
+                                                              const wickr_ec_key_t *key,
+                                                              const wickr_buffer_t *identifier)
+{
+    if (!key || !identifier) {
+        return NULL;
+    }
+    
+    wickr_buffer_t *concat_buffer = wickr_buffer_concat(identifier, key->pub_data);
+    
+    wickr_fingerprint_t *fingerprint = __wickr_fingerprint_sha512_create(engine, concat_buffer);
+    wickr_buffer_destroy(&concat_buffer);
+    
+    return fingerprint;
+}
+
+static wickr_fingerprint_t *__wickr_fingerprint_sha512_combine(wickr_crypto_engine_t engine,
+                                                               const wickr_fingerprint_t *f1,
+                                                               const wickr_fingerprint_t *f2)
+{
+    if (!f1 || !f2) {
+        return NULL;
+    }
+    
+    if (f1->data->length != f2->data->length) {
+        return NULL;
+    }
+    
+    wickr_buffer_t *concat_buffer = NULL;
+    
+    /* Order the input fingerprints in a consistent way so that outputs are consistent
+       regardless of input order */
+    for (unsigned i = 0; i < f1->data->length; i++) {
+        
+        if (f1->data->bytes[i] == f2->data->bytes[i]) {
+            continue;
+        }
+        
+        if (f1->data->bytes[i] > f2->data->bytes[i]) {
+            concat_buffer = wickr_buffer_concat(f1->data, f2->data);
+            break;
+        }
+        else {
+            concat_buffer = wickr_buffer_concat(f2->data, f1->data);
+            break;
+        }
+        
+    }
+    
+    if (!concat_buffer) {
+        return NULL;
+    }
+    
+    wickr_fingerprint_t *fingerprint = __wickr_fingerprint_sha512_create(engine, concat_buffer);
+    wickr_buffer_destroy(&concat_buffer);
+    
+    return fingerprint;
+}
+
+wickr_fingerprint_t *wickr_fingerprint_gen(wickr_crypto_engine_t engine,
+                                           const wickr_ec_key_t *key,
+                                           const wickr_buffer_t *identifier,
+                                           wickr_fingerprint_type type)
+{
+    switch (type) {
+        case WICKR_FINGERPRINT_TYPE_SHA512:
+            return __wickr_fingerprint_sha512_encode(engine, key, identifier);
+        default:
+            return NULL;
+    }
+}
+
+wickr_fingerprint_t *wickr_fingerprint_gen_bilateral(wickr_crypto_engine_t engine,
+                                                     const wickr_fingerprint_t *local,
+                                                     const wickr_fingerprint_t *remote,
+                                                     wickr_fingerprint_type type)
+{
+    switch (type) {
+        case WICKR_FINGERPRINT_TYPE_SHA512:
+            return __wickr_fingerprint_sha512_combine(engine, local, remote);
+        default:
+            return NULL;
+    }
+}
+
+wickr_fingerprint_t *wickr_fingerprint_create(wickr_buffer_t *data)
+{
+    if (!data) {
+        return NULL;
+    }
+    
+    wickr_fingerprint_t *fingerprint = wickr_alloc_zero(sizeof(wickr_fingerprint_t));
+    
+    if (!fingerprint) {
+        return NULL;
+    }
+    
+    fingerprint->data = data;
+    
+    return fingerprint;
+}
+
+wickr_fingerprint_t *wickr_fingerprint_copy(const wickr_fingerprint_t *fingerprint)
+{
+    if (!fingerprint) {
+        return NULL;
+    }
+    
+    wickr_buffer_t *data_copy = wickr_buffer_copy(fingerprint->data);
+    
+    if (!data_copy) {
+        return NULL;
+    }
+    
+    wickr_fingerprint_t *copy = wickr_fingerprint_create(data_copy);
+    
+    if (!copy) {
+        wickr_buffer_destroy(&data_copy);
+    }
+    
+    return copy;
+}
+
+void wickr_fingerprint_destroy(wickr_fingerprint_t **fingerprint)
+{
+    if (!fingerprint || !*fingerprint) {
+        return;
+    }
+    
+    wickr_buffer_destroy(&(*fingerprint)->data);
+    wickr_free(*fingerprint);
+    *fingerprint = NULL;
+}
+
+typedef wickr_buffer_t *(*wickr_fingerprint_encode_func)(const wickr_buffer_t *);
+
+static wickr_buffer_t *__wickr_fingerprint_encode_for_output_mode(const wickr_fingerprint_t *fingerprint,
+                                                                  wickr_fingerprint_output output_mode,
+                                                                  wickr_fingerprint_encode_func enc_func)
+{
+    if (!fingerprint) {
+        return NULL;
+    }
+    
+    wickr_buffer_t *encoded_fingerprint_data = enc_func(fingerprint->data);
+    
+    if (output_mode == FINGERPRINT_OUTPUT_SHORT) {
+        encoded_fingerprint_data->length = encoded_fingerprint_data->length / 2;
+    }
+        
+    return encoded_fingerprint_data;
+    
+}
+
+wickr_buffer_t *wickr_fingerprint_get_b32(const wickr_fingerprint_t *fingerprint, wickr_fingerprint_output output_mode)
+{
+    return __wickr_fingerprint_encode_for_output_mode(fingerprint, output_mode, base32_encode);
+}
+
+wickr_buffer_t *wickr_fingerprint_get_hex(const wickr_fingerprint_t *fingerprint, wickr_fingerprint_output output_mode)
+{
+    return __wickr_fingerprint_encode_for_output_mode(fingerprint, output_mode, getHexStringFromData);
+}

--- a/src/wickrcrypto/src/identity.c
+++ b/src/wickrcrypto/src/identity.c
@@ -160,6 +160,55 @@ wickr_identity_t *wickr_identity_create_from_buffer(const wickr_buffer_t *buffer
     return return_identity;
 }
 
+wickr_fingerprint_t *wickr_identity_get_fingerprint(const wickr_identity_t *identity,
+                                                    wickr_crypto_engine_t engine)
+{
+    if (!identity) {
+        return NULL;
+    }
+    
+    return wickr_fingerprint_gen(engine, identity->sig_key,
+                                 identity->identifier, WICKR_FINGERPRINT_TYPE_SHA512);
+}
+
+wickr_fingerprint_t *wickr_identity_get_bilateral_fingerprint(const wickr_identity_t *identity,
+                                                              const wickr_identity_t *remote_identity,
+                                                              wickr_crypto_engine_t engine)
+{
+    if (!identity || !remote_identity) {
+        return NULL;
+    }
+    
+    wickr_fingerprint_t *local_fingerprint = wickr_fingerprint_gen(engine,
+                                                                   identity->sig_key,
+                                                                   identity->identifier,
+                                                                   WICKR_FINGERPRINT_TYPE_SHA512);
+    
+    if (!local_fingerprint) {
+        return NULL;
+    }
+    
+    wickr_fingerprint_t *remote_fingerprint = wickr_fingerprint_gen(engine,
+                                                                    remote_identity->sig_key,
+                                                                    remote_identity->identifier,
+                                                                    WICKR_FINGERPRINT_TYPE_SHA512);
+    
+    if (!remote_fingerprint) {
+        wickr_fingerprint_destroy(&local_fingerprint);
+        return NULL;
+    }
+    
+    wickr_fingerprint_t *merged_fingerprint = wickr_fingerprint_gen_bilateral(engine,
+                                                                              local_fingerprint,
+                                                                              remote_fingerprint,
+                                                                              WICKR_FINGERPRINT_TYPE_SHA512);
+    
+    wickr_fingerprint_destroy(&remote_fingerprint);
+    wickr_fingerprint_destroy(&local_fingerprint);
+    
+    return merged_fingerprint;
+}
+
 wickr_identity_chain_t *wickr_identity_chain_create(wickr_identity_t *root, wickr_identity_t *node)
 {
     if (!root || !node) {

--- a/src/wickrcrypto/swig/fingerprint.i
+++ b/src/wickrcrypto/swig/fingerprint.i
@@ -1,0 +1,49 @@
+%module fingerprint
+
+%include engine.i
+
+%{
+#include <wickrcrypto/fingerprint.h>
+%}
+
+%ignore wickr_fingerprint_gen;
+%ignore wickr_fingerprint_gen_bilateral;
+%ignore wickr_fingerprint_create;
+%ignore wickr_fingerprint_copy;
+%ignore wickr_fingerprint_destroy;
+%ignore wickr_fingerprint_get_b32;
+%ignore wickr_fingerprint_get_hex;
+
+%immutable;
+
+%include "wickrcrypto/fingerprint.h"
+
+%extend struct wickr_fingerprint {
+
+    %typemap(javacode) struct wickr_fingerprint %{
+
+    public String getBase32String(FingerprintOutputType outputType) throws UnsupportedEncodingException {
+        return new String(this.getB32(outputType), "UTF-8");
+    }
+
+    public String getHexString(FingerprintOutputType outputType) throws UnsupportedEncodingException {
+        return new String(this.getHex(outputType), "UTF-8");
+    }
+
+    %}
+
+    %typemap(javaimports) struct wickr_fingerprint %{
+    import java.io.*;
+    %}
+
+    ~wickr_fingerprint() {
+        wickr_fingerprint_destroy(&$self);
+    }
+
+    %newobject get_b32;
+    %newobject get_hex;
+
+    wickr_buffer_t *get_b32(wickr_fingerprint_output output_mode);
+    wickr_buffer_t *get_hex(wickr_fingerprint_output output_mode);
+
+};

--- a/src/wickrcrypto/swig/identity.i
+++ b/src/wickrcrypto/swig/identity.i
@@ -1,6 +1,7 @@
 %module identity
 
 %include engine.i
+%include fingerprint.i
 %include <stdint.i>
 
 %{
@@ -35,6 +36,8 @@
 %ignore wickr_identity_chain_destroy;
 %ignore wickr_identity_chain_serialize;
 %ignore wickr_identity_chain_create_from_buffer;
+%ignore wickr_identity_get_fingerprint;
+%ignore wickr_identity_get_bilateral_fingerprint;
 
 %include "wickrcrypto/identity.h"
 
@@ -48,6 +51,9 @@
  %newobject sign_data;
  %newobject gen_node;
  %newobject from_buffer;
+ %newobject get_fingerprint;
+ %newobject get_bilateral_fingerprint;
+ %newobject serialize;
 
  static wickr_identity_t *from_buffer(const wickr_buffer_t *data) {
      const wickr_crypto_engine_t engine = wickr_crypto_engine_get_default();
@@ -76,6 +82,16 @@
    	}
    	return identity;
  }
+
+ wickr_fingerprint_t *fingerprint() {
+   wickr_crypto_engine_t engine = wickr_crypto_engine_get_default();
+   return wickr_identity_get_fingerprint($self, engine);
+ }
+
+ wickr_fingerprint_t *bilateral_fingerprint(const wickr_identity_t *remote_identity) {
+   wickr_crypto_engine_t engine = wickr_crypto_engine_get_default();
+   return wickr_identity_get_bilateral_fingerprint($self, remote_identity, engine);
+ }
  
 
 };
@@ -88,6 +104,7 @@
 
  %newobject from_identities;
  %newobject from_buffer;
+ %newobject serialize;
 
  static wickr_identity_chain_t *from_buffer(const wickr_buffer_t *data) {
      const wickr_crypto_engine_t engine = wickr_crypto_engine_get_default();

--- a/src/wickrcrypto/swig/interface.i
+++ b/src/wickrcrypto/swig/interface.i
@@ -46,11 +46,13 @@
 %rename(ContextDecodeResult) wickr_decode_result;
 %rename(ContextGenResult) wickr_ctx_gen_result;
 %rename(EphemeralInfo) wickr_ephemeral_info;
+%rename(Fingerprint) wickr_fingerprint;
 
 %rename(DigestType) wickr_digest_type;
 %rename(IdentityChainStatus) wickr_identity_chain_status;
 %rename(IdentityType) wickr_identity_type;
 %rename(PacketSignatureStatus) wickr_packet_signature_status;
+%rename(FingerprintOutputType) wickr_fingerprint_output;
 
 %rename (DecodeError) wickr_decode_error;
 %rename (CipherID) wickr_cipher_id;

--- a/src/wickrcrypto/swig/java/CMakeLists.txt
+++ b/src/wickrcrypto/swig/java/CMakeLists.txt
@@ -48,7 +48,8 @@ set(JAVA_SOURCES
     ${CMAKE_SWIG_OUTDIR}/ECDSAResult.java
     ${CMAKE_SWIG_OUTDIR}/ECKey.java
     ${CMAKE_SWIG_OUTDIR}/EphemeralInfo.java 
-    ${CMAKE_SWIG_OUTDIR}/EphemeralKeypair.java 
+    ${CMAKE_SWIG_OUTDIR}/EphemeralKeypair.java
+    ${CMAKE_SWIG_OUTDIR}/Fingerprint.java 
     ${CMAKE_SWIG_OUTDIR}/Identity.java
     ${CMAKE_SWIG_OUTDIR}/IdentityChain.java
     ${CMAKE_SWIG_OUTDIR}/IdentityChainStatus.java

--- a/src/wickrcrypto/swig/java/com/wickr/crypto/tests/FingerprintTests.java
+++ b/src/wickrcrypto/swig/java/com/wickr/crypto/tests/FingerprintTests.java
@@ -1,0 +1,46 @@
+package com.wickr.crypto.tests;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
+import org.junit.Test;
+import org.junit.Before;
+import com.wickr.crypto.*;
+import java.io.*;
+import java.util.*;
+
+public class FingerprintTests
+{
+
+    protected Fingerprint testFingerprint;
+        
+    @Before
+    public void setUp() throws UnsupportedEncodingException
+    {
+        byte[] identifier = CryptoEngine.digest("wickr".getBytes("UTF8"), null, Digest.sha256());
+        ECKey sigKey = CryptoEngine.randEcKey(ECCurve.p521());
+        Identity testIdentity = Identity.fromValues(IdentityType.IDENTITY_TYPE_ROOT, identifier, sigKey, null);
+        this.testFingerprint = testIdentity.fingerprint();
+    }
+
+    @Test
+    public void testEncodings() throws UnsupportedEncodingException
+    {
+
+        // Verify that encodings are working correctly
+        String hexStringShort = testFingerprint.getHexString(FingerprintOutputType.FINGERPRINT_OUTPUT_SHORT);
+        String base32StringShort = testFingerprint.getBase32String(FingerprintOutputType.FINGERPRINT_OUTPUT_SHORT);
+
+        String hexStringLong = testFingerprint.getHexString(FingerprintOutputType.FINGERPRINT_OUTPUT_LONG);
+        String base32StringLong = testFingerprint.getBase32String(FingerprintOutputType.FINGERPRINT_OUTPUT_LONG);
+
+        assertTrue(hexStringLong.length() != testFingerprint.getData().length);
+        assertTrue(hexStringLong.length() > hexStringShort.length());
+
+        assertTrue(base32StringLong.length() != testFingerprint.getData().length);
+        assertTrue(base32StringLong.length() > base32StringShort.length());
+
+    }
+
+
+}
+

--- a/src/wickrcrypto/swig/java/com/wickr/crypto/tests/IdentityTests.java
+++ b/src/wickrcrypto/swig/java/com/wickr/crypto/tests/IdentityTests.java
@@ -80,6 +80,34 @@ public class IdentityTests
 	}
 
 	@Test
+	public void testFingerprints() throws UnsupportedEncodingException {
+
+		// Create a second identity
+		byte[] identifier2 = CryptoEngine.digest("wickr2".getBytes("UTF8"), null, Digest.sha256());
+        ECKey sigKey2 = CryptoEngine.randEcKey(ECCurve.p521());
+        Identity identity2 = Identity.fromValues(IdentityType.IDENTITY_TYPE_ROOT, identifier2, sigKey2, null);
+
+		//Create a fingerprint from the test identity
+		Fingerprint fingerprint = testIdentity.fingerprint();
+		Fingerprint fingerprintId2 = identity2.fingerprint();
+
+		assertNotNull(fingerprint);
+		assertEquals(fingerprint.getData().length, 64);
+
+		// Verify fingerprints are unique per identity
+		assertThat(fingerprint.getData(), not(equalTo(fingerprintId2.getData())));
+
+		//Create a bilateral fingerprint from the test identity
+		
+        Fingerprint bilateralFingerprint = testIdentity.bilateralFingerprint(identity2);
+        assertNotNull(bilateralFingerprint);
+        assertThat(bilateralFingerprint.getData(), not(equalTo(fingerprintId2.getData())));
+        assertThat(bilateralFingerprint.getData(), not(equalTo(fingerprint.getData())));
+		assertEquals(bilateralFingerprint.getData().length, 64);
+
+	}
+
+	@Test
 	public void testChainSerialization() {
 
 		// Serialize and deserialize an identity chain

--- a/src/wickrcrypto/swig/java/com/wickr/crypto/tests/WickrRunner.java
+++ b/src/wickrcrypto/swig/java/com/wickr/crypto/tests/WickrRunner.java
@@ -6,7 +6,7 @@ import org.junit.runner.notification.Failure;
 
 public class WickrRunner {
   public static void main(String[] args) {
-    Result result = JUnitCore.runClasses(CryptoTests.class, DevInfoTests.class, KeyStoreTests.class, NodeTests.class, IdentityTests.class, ContextTests.class, ECDHCipherTests.class);
+    Result result = JUnitCore.runClasses(CryptoTests.class, DevInfoTests.class, KeyStoreTests.class, NodeTests.class, IdentityTests.class, ContextTests.class, ECDHCipherTests.class, FingerprintTests.class);
 
     System.out.println("Completed " + 
     					result.getRunCount() + 

--- a/test/main.c
+++ b/test/main.c
@@ -20,6 +20,7 @@
 #include "test_ecdh_cipher.h"
 #include "test_protocol_version.h"
 #include "test_storage_keys.h"
+#include "test_b32.h"
 
 #include "cspec_output_unit.h"
 
@@ -39,6 +40,7 @@ void run_primitive_tests(CSpecOutputStruct *output)
     CSpec_Run(DESCRIPTION(getDataFromBase64), output);
     CSpec_Run(DESCRIPTION(getHexStringFromData), output);
     CSpec_Run(DESCRIPTION(getDataFromHexString), output);
+    CSpec_Run(DESCRIPTION(base32_encode), output);
     CSpec_Run(DESCRIPTION(wickr_kdf_meta), output);
     CSpec_Run(DESCRIPTION(wickr_kdf_result), output);
     CSpec_Run(DESCRIPTION(packet_meta), output);

--- a/test/main.c
+++ b/test/main.c
@@ -21,6 +21,7 @@
 #include "test_protocol_version.h"
 #include "test_storage_keys.h"
 #include "test_b32.h"
+#include "test_fingerprint.h"
 
 #include "cspec_output_unit.h"
 
@@ -30,6 +31,9 @@ void run_primitive_tests(CSpecOutputStruct *output)
 {
     CSpec_Run(DESCRIPTION(wickr_buffer_tests), output);
     CSpec_Run(DESCRIPTION(node_tests), output);
+    CSpec_Run(DESCRIPTION(wickr_fingerprint), output);
+    CSpec_Run(DESCRIPTION(wickr_fingerprint_generation), output);
+    CSpec_Run(DESCRIPTION(wickr_fingerprint_bilateral_generation), output);
     CSpec_Run(DESCRIPTION(identity), output);
     CSpec_Run(DESCRIPTION(identity_chain), output);
     CSpec_Run(DESCRIPTION(ephemeral_keypair), output);

--- a/test/test_b32.c
+++ b/test/test_b32.c
@@ -1,0 +1,39 @@
+
+#include "test_b32.h"
+#include "b32.h"
+#include "string.h"
+
+DESCRIBE(base32_encode, "base32 encoding")
+{
+    const char *test_string = "00-base32-wickr-crypto-c";
+    const char *test_encoded = "60R2TRK1EDJK6CHDEXMP6TVJ5NHQ4YBGEHQJTRR";
+    
+    wickr_buffer_t test_buffer = { .bytes = (uint8_t *)test_string, .length = strlen(test_string) };
+    wickr_buffer_t test_encoded_buffer = { .bytes = (uint8_t *)test_encoded, .length = strlen(test_encoded) };
+    
+    IT("should be able to encode and decode buffers")
+    {
+        /* Encode and verify it matches the sample data */
+        wickr_buffer_t *encoded_buffer = base32_encode(&test_buffer);
+        SHOULD_NOT_BE_NULL(encoded_buffer);
+        SHOULD_BE_TRUE(wickr_buffer_is_equal(&test_encoded_buffer, encoded_buffer, NULL));
+        
+        /* Decode and verify that it matches the original input */
+        wickr_buffer_t *decoded_buffer = base32_decode(&test_encoded_buffer);
+        SHOULD_BE_TRUE(wickr_buffer_is_equal(decoded_buffer, &test_buffer, NULL));
+        
+        /* Cleanup */
+        wickr_buffer_destroy(&encoded_buffer);
+        wickr_buffer_destroy(&decoded_buffer);
+    }
+    END_IT
+    
+    IT("should handle decode errors")
+    {
+        SHOULD_BE_NULL(base32_decode(NULL));
+        SHOULD_BE_NULL(base32_decode(&test_buffer));
+    }
+    END_IT
+    
+}
+END_DESCRIBE

--- a/test/test_b32.h
+++ b/test/test_b32.h
@@ -1,0 +1,9 @@
+
+#ifndef test_b32_h
+#define test_b32_h
+
+#include "cspec.h"
+
+DEFINE_DESCRIPTION(base32_encode)
+
+#endif /* test_b32_h */

--- a/test/test_fingerprint.c
+++ b/test/test_fingerprint.c
@@ -1,0 +1,247 @@
+
+#include "test_fingerprint.h"
+#include "crypto_engine.h"
+#include "fingerprint.h"
+#include "string.h"
+#include "util.h"
+#include "b32.h"
+
+typedef wickr_buffer_t *(*wickr_fingerprint_encode_func)(const wickr_fingerprint_t *, wickr_fingerprint_output);
+
+static void __test_fingerprint_encoding(const wickr_fingerprint_t *test_fingerprint,
+                                        const wickr_buffer_t *expected,
+                                        wickr_fingerprint_encode_func test_encode_func)
+{
+    
+    wickr_buffer_t *long_fingerprint = test_encode_func(test_fingerprint, FINGERPRINT_OUTPUT_LONG);
+    wickr_buffer_t *short_fingerprint = test_encode_func(test_fingerprint, FINGERPRINT_OUTPUT_SHORT);
+    
+    SHOULD_BE_TRUE(wickr_buffer_is_equal(expected, long_fingerprint, NULL));
+    
+    /* Shorten expected buffer to test short encoding */
+    wickr_buffer_t *expected_short = wickr_buffer_copy_section(expected, 0, expected->length / 2);
+    
+    SHOULD_BE_TRUE(wickr_buffer_is_equal(expected_short, short_fingerprint, NULL));
+    
+    wickr_buffer_destroy(&expected_short);
+    wickr_buffer_destroy(&long_fingerprint);
+    wickr_buffer_destroy(&short_fingerprint);
+}
+
+DESCRIBE(wickr_fingerprint, "fingerprints")
+{
+    wickr_crypto_engine_t test_engine = wickr_crypto_engine_get_default();
+    
+    wickr_buffer_t *rnd_data = test_engine.wickr_crypto_engine_crypto_random(32);
+    SHOULD_NOT_BE_NULL(rnd_data);
+    
+    wickr_fingerprint_t *test_fingerprint = wickr_fingerprint_create(rnd_data);
+    
+    IT("can be created with raw fingerprint data")
+    {
+        SHOULD_BE_NULL(wickr_fingerprint_create(NULL));
+        SHOULD_NOT_BE_NULL(test_fingerprint);
+        SHOULD_EQUAL(test_fingerprint->data, rnd_data);
+    }
+    END_IT
+    
+    IT("can be copied")
+    {
+        wickr_fingerprint_t *copy = wickr_fingerprint_copy(test_fingerprint);
+        SHOULD_NOT_BE_NULL(copy);
+        SHOULD_BE_TRUE(wickr_buffer_is_equal(test_fingerprint->data, copy->data, NULL));
+        wickr_fingerprint_destroy(&copy);
+    }
+    END_IT
+    
+    IT("can be represented in hex")
+    {
+        wickr_buffer_t *expected_hex = getHexStringFromData(test_fingerprint->data);
+        __test_fingerprint_encoding(test_fingerprint, expected_hex, wickr_fingerprint_get_hex);
+    }
+    END_IT
+    
+    IT("can be represented in base32")
+    {
+        wickr_buffer_t *expected_b32 = base32_encode(test_fingerprint->data);
+        __test_fingerprint_encoding(test_fingerprint, expected_b32, wickr_fingerprint_get_b32);
+    }
+    END_IT
+    
+    wickr_fingerprint_destroy(&test_fingerprint);
+    SHOULD_BE_NULL(test_fingerprint);
+}
+END_DESCRIBE
+
+DESCRIBE(wickr_fingerprint_generation, "unilateral fingerprint")
+{
+    wickr_crypto_engine_t test_engine = wickr_crypto_engine_get_default();
+    wickr_buffer_t *test_identifier = test_engine.wickr_crypto_engine_crypto_random(32);
+    wickr_ec_key_t *test_key = test_engine.wickr_crypto_engine_ec_rand_key(EC_CURVE_NIST_P521);
+    
+    SHOULD_NOT_BE_NULL(test_identifier);
+    SHOULD_NOT_BE_NULL(test_key);
+    
+    wickr_fingerprint_t *test_fingerprint = wickr_fingerprint_gen(test_engine,
+                                                                  test_key,
+                                                                  test_identifier,
+                                                                  WICKR_FINGERPRINT_TYPE_SHA512);
+    
+    IT("can generate a SHA512 length fingerprint")
+    {
+        SHOULD_NOT_BE_NULL(test_fingerprint);
+        SHOULD_NOT_BE_NULL(test_fingerprint->data)
+        SHOULD_EQUAL(test_fingerprint->data->length, DIGEST_SHA_512.size);
+        
+        SHOULD_BE_NULL(wickr_fingerprint_gen(test_engine, NULL, NULL, WICKR_FINGERPRINT_TYPE_SHA512));
+        SHOULD_BE_NULL(wickr_fingerprint_gen(test_engine, test_key,
+                                             NULL, WICKR_FINGERPRINT_TYPE_SHA512));
+        SHOULD_BE_NULL(wickr_fingerprint_gen(test_engine, NULL,
+                                             test_identifier, WICKR_FINGERPRINT_TYPE_SHA512));
+        SHOULD_BE_NULL(wickr_fingerprint_gen(test_engine, test_key,
+                                             test_identifier, 1));
+    }
+    END_IT
+    
+    IT("generates fingerprints that are unique per key")
+    {
+        wickr_ec_key_t *test_key2 = test_engine.wickr_crypto_engine_ec_rand_key(EC_CURVE_NIST_P521);
+        SHOULD_NOT_BE_NULL(test_key2);
+        
+        wickr_fingerprint_t *test_fingerprint_key2 = wickr_fingerprint_gen(test_engine,
+                                                                           test_key2,
+                                                                           test_identifier,
+                                                                           WICKR_FINGERPRINT_TYPE_SHA512);
+        
+        SHOULD_NOT_BE_NULL(test_fingerprint_key2);
+        
+        SHOULD_BE_FALSE(wickr_buffer_is_equal(test_fingerprint_key2->data, test_fingerprint->data, NULL));
+        
+        wickr_fingerprint_destroy(&test_fingerprint_key2);
+        wickr_ec_key_destroy(&test_key2);
+    }
+    END_IT
+    
+    IT("generates fingerprints that are only based on the public part of the key")
+    {
+        wickr_ec_key_t *pub_only_key = wickr_ec_key_copy(test_key);
+        wickr_buffer_destroy(&pub_only_key->pri_data);
+        
+        SHOULD_NOT_BE_NULL(pub_only_key);
+        SHOULD_BE_NULL(pub_only_key->pri_data);
+        
+        wickr_fingerprint_t *pub_only_fingerprint = wickr_fingerprint_gen(test_engine, pub_only_key, test_identifier, WICKR_FINGERPRINT_TYPE_SHA512);
+        
+        SHOULD_NOT_BE_NULL(pub_only_fingerprint);
+        SHOULD_BE_TRUE(wickr_buffer_is_equal(pub_only_fingerprint->data, test_fingerprint->data, NULL));
+        
+        wickr_fingerprint_destroy(&pub_only_fingerprint);
+        wickr_ec_key_destroy(&pub_only_key);
+    }
+    END_IT
+    
+    IT("generates fingerprints that are unique per identifier")
+    {
+        wickr_buffer_t *identifier2 = test_engine.wickr_crypto_engine_crypto_random(32);
+        SHOULD_NOT_BE_NULL(identifier2);
+        
+        wickr_fingerprint_t *test_fingerprint_id2 = wickr_fingerprint_gen(test_engine, test_key, identifier2, WICKR_FINGERPRINT_TYPE_SHA512);
+        SHOULD_NOT_BE_NULL(test_fingerprint_id2);
+        
+        SHOULD_BE_FALSE(wickr_buffer_is_equal(test_fingerprint_id2->data, test_fingerprint->data, NULL));
+        
+        wickr_fingerprint_destroy(&test_fingerprint_id2);
+        wickr_buffer_destroy(&identifier2);
+    }
+    END_IT
+    
+    wickr_buffer_destroy(&test_identifier);
+    wickr_ec_key_destroy(&test_key);
+    
+}
+END_DESCRIBE
+
+static wickr_fingerprint_t *__wickr_fingerprint_gen_random(wickr_crypto_engine_t engine)
+{
+    wickr_buffer_t *identifier = engine.wickr_crypto_engine_crypto_random(32);
+    wickr_ec_key_t *key = engine.wickr_crypto_engine_ec_rand_key(EC_CURVE_NIST_P521);
+    
+    SHOULD_NOT_BE_NULL(identifier);
+    SHOULD_NOT_BE_NULL(key);
+    
+    
+    wickr_fingerprint_t *fingerprint = wickr_fingerprint_gen(engine, key,
+                                                                    identifier, WICKR_FINGERPRINT_TYPE_SHA512);
+    
+    SHOULD_NOT_BE_NULL(fingerprint);
+    
+    wickr_buffer_destroy(&identifier);
+    wickr_ec_key_destroy(&key);
+    
+    return fingerprint;
+}
+
+DESCRIBE(wickr_fingerprint_bilateral_generation, "bilateral fingerprint")
+{
+    wickr_crypto_engine_t test_engine = wickr_crypto_engine_get_default();
+
+    wickr_fingerprint_t *test_fingerprint_a = __wickr_fingerprint_gen_random(test_engine);
+    wickr_fingerprint_t *test_fingerprint_b = __wickr_fingerprint_gen_random(test_engine);
+    
+    wickr_fingerprint_t *test_bilateral_fingerprint = wickr_fingerprint_gen_bilateral(test_engine,
+                                                                                      test_fingerprint_a,
+                                                                                      test_fingerprint_b,
+                                                                                      WICKR_FINGERPRINT_TYPE_SHA512);
+
+    IT("can be generated from two existing fingerprints")
+    {
+        SHOULD_NOT_BE_NULL(test_bilateral_fingerprint);
+        SHOULD_NOT_BE_NULL(test_bilateral_fingerprint->data)
+        SHOULD_EQUAL(test_bilateral_fingerprint->data->length, DIGEST_SHA_512.size);
+        
+        SHOULD_BE_NULL(wickr_fingerprint_gen_bilateral(test_engine, NULL, NULL, WICKR_FINGERPRINT_TYPE_SHA512));
+        SHOULD_BE_NULL(wickr_fingerprint_gen_bilateral(test_engine, test_fingerprint_a,
+                                                       NULL, WICKR_FINGERPRINT_TYPE_SHA512));
+        SHOULD_BE_NULL(wickr_fingerprint_gen_bilateral(test_engine, NULL,
+                                                       test_fingerprint_b, WICKR_FINGERPRINT_TYPE_SHA512));
+    }
+    END_IT
+    
+    IT("should generate fingerprints that are not dependent on input order")
+    {
+        wickr_fingerprint_t *test_bilateral_fingerprint2 = wickr_fingerprint_gen_bilateral(test_engine,
+                                                                                           test_fingerprint_b,
+                                                                                           test_fingerprint_a,
+                                                                                           WICKR_FINGERPRINT_TYPE_SHA512);
+        SHOULD_NOT_BE_NULL(test_bilateral_fingerprint2);
+        
+        SHOULD_BE_TRUE(wickr_buffer_is_equal(test_bilateral_fingerprint->data, test_bilateral_fingerprint2->data, NULL));
+        
+        wickr_fingerprint_destroy(&test_bilateral_fingerprint2);
+    }
+    END_IT
+    
+    IT("should generate fingerprints that are unique per inputs provided")
+    {
+        wickr_fingerprint_t *test_fingerprint_c = __wickr_fingerprint_gen_random(test_engine);
+        SHOULD_NOT_BE_NULL(test_fingerprint_c);
+        
+        wickr_fingerprint_t *test_bilateral_ac = wickr_fingerprint_gen_bilateral(test_engine,
+                                                                                 test_fingerprint_a,
+                                                                                 test_fingerprint_c,
+                                                                                 WICKR_FINGERPRINT_TYPE_SHA512);
+        
+        SHOULD_NOT_BE_NULL(test_bilateral_ac);
+        
+        SHOULD_BE_FALSE(wickr_buffer_is_equal(test_bilateral_ac->data, test_bilateral_fingerprint->data, NULL));
+        
+        wickr_fingerprint_destroy(&test_fingerprint_c);
+        wickr_fingerprint_destroy(&test_bilateral_ac);
+    }
+    END_IT
+    
+    wickr_fingerprint_destroy(&test_fingerprint_a);
+    wickr_fingerprint_destroy(&test_fingerprint_b);
+    wickr_fingerprint_destroy(&test_bilateral_fingerprint);
+}
+END_DESCRIBE

--- a/test/test_fingerprint.h
+++ b/test/test_fingerprint.h
@@ -1,0 +1,11 @@
+
+#ifndef test_fingerprint_h
+#define test_fingerprint_h
+
+#include "cspec.h"
+
+DEFINE_DESCRIPTION(wickr_fingerprint)
+DEFINE_DESCRIPTION(wickr_fingerprint_generation)
+DEFINE_DESCRIPTION(wickr_fingerprint_bilateral_generation)
+
+#endif /* test_fingerprint_h */

--- a/test/test_identity.c
+++ b/test/test_identity.c
@@ -98,6 +98,56 @@ DESCRIBE(identity, "identity tests")
     }
     END_IT
     
+    IT("has a fingerprint")
+    {
+        SHOULD_BE_NULL(wickr_identity_get_fingerprint(NULL, engine));
+
+        wickr_fingerprint_t *fingerprint = wickr_identity_get_fingerprint(test_identity, engine);
+        SHOULD_NOT_BE_NULL(fingerprint);
+        
+        wickr_fingerprint_t *manual_fingerprint = wickr_fingerprint_gen(engine, test_identity->sig_key,
+                                                                        test_identity->identifier,
+                                                                        WICKR_FINGERPRINT_TYPE_SHA512);
+        
+        SHOULD_NOT_BE_NULL(manual_fingerprint);
+        
+        SHOULD_BE_TRUE(wickr_buffer_is_equal(manual_fingerprint->data, fingerprint->data, NULL));
+        
+        wickr_fingerprint_destroy(&fingerprint);
+        wickr_fingerprint_destroy(&manual_fingerprint);
+    }
+    END_IT
+    
+    IT("can make a bilateral fingerprint with another identity")
+    {
+        wickr_buffer_t *test_identifier = engine.wickr_crypto_engine_crypto_random(32);
+        wickr_ec_key_t *test_sig_key = engine.wickr_crypto_engine_ec_rand_key(EC_CURVE_NIST_P521);
+        wickr_identity_t *test_identity_b = wickr_identity_create(IDENTITY_TYPE_ROOT, test_identifier, test_sig_key, NULL);
+        
+        wickr_fingerprint_t *fingerprint = wickr_identity_get_bilateral_fingerprint(test_identity, test_identity_b, engine);
+        
+        SHOULD_NOT_BE_NULL(fingerprint);
+        
+        wickr_fingerprint_t *manual_a = wickr_fingerprint_gen(engine, test_identity->sig_key,
+                                                              test_identity->identifier, WICKR_FINGERPRINT_TYPE_SHA512);
+        
+        wickr_fingerprint_t *manual_b = wickr_fingerprint_gen(engine, test_identity_b->sig_key,
+                                                              test_identity_b->identifier, WICKR_FINGERPRINT_TYPE_SHA512);
+        
+        wickr_fingerprint_t *manual = wickr_fingerprint_gen_bilateral(engine, manual_a,
+                                                                      manual_b, WICKR_FINGERPRINT_TYPE_SHA512);
+        
+        SHOULD_NOT_BE_NULL(manual);
+        SHOULD_BE_TRUE(wickr_buffer_is_equal(manual->data, fingerprint->data, NULL));
+        
+        wickr_fingerprint_destroy(&manual_a);
+        wickr_fingerprint_destroy(&manual_b);
+        wickr_fingerprint_destroy(&manual);
+        wickr_identity_destroy(&test_identity_b);
+        wickr_fingerprint_destroy(&fingerprint);
+    }
+    END_IT
+    
     wickr_identity_destroy(&test_identity);
     SHOULD_BE_NULL(test_identity);
 }


### PR DESCRIPTION
* Support for base32 encoding / decoding of wickr_buffer_t 
* Support for both individual identity fingerprints as well as bilateral fingerprints
* Fingerprints are computed with SHA512
* Fingerprints can be represented as raw bytes, hex, or base32. String representations can be either short (32 bytes) or long (64 bytes)
* Identity fingerprints are supported in Java / Javascript SWIG wrappers