### PR TITLE
Fingerprint calculation patches

### DIFF
--- a/src/wickrcrypto/include/wickrcrypto/fingerprint.h
+++ b/src/wickrcrypto/include/wickrcrypto/fingerprint.h
@@ -48,24 +48,7 @@ typedef enum {
     FINGERPRINT_OUTPUT_SHORT,
     FINGERPRINT_OUTPUT_LONG
 } wickr_fingerprint_output;
-
-/**
- 
- @ingroup wickr_fingerprint
- 
- @struct wickr_fingerprint
- 
- @brief A fingerprint representation of a combination of signature keys / identifiers
- @var wickr_fingerprint::data
- a raw data representation of the fingerprint
-
- */
-struct wickr_fingerprint {
-    wickr_buffer_t *data;
-};
-
-typedef struct wickr_fingerprint wickr_fingerprint_t;
-
+    
 /**
  
  @ingroup wickr_fingerprint
@@ -77,6 +60,24 @@ typedef struct wickr_fingerprint wickr_fingerprint_t;
  */
 typedef enum { WICKR_FINGERPRINT_TYPE_SHA512 } wickr_fingerprint_type;
 
+/**
+ 
+ @ingroup wickr_fingerprint
+ 
+ @struct wickr_fingerprint
+ 
+ @brief A fingerprint representation of a combination of signature keys / identifiers
+ @var wickr_fingerprint::type
+ type the type of fingerprint algorithm to use when processing key/identifier
+ @var wickr_fingerprint::data
+ a raw data representation of the fingerprint
+ */
+struct wickr_fingerprint {
+    wickr_fingerprint_type type;
+    wickr_buffer_t *data;
+};
+
+typedef struct wickr_fingerprint wickr_fingerprint_t;
 
 /**
  
@@ -120,10 +121,11 @@ wickr_fingerprint_t *wickr_fingerprint_gen_bilateral(wickr_crypto_engine_t engin
  
  Create a new wickr_fingerprint struct
 
+ @param type see 'wickr_fingerprint' property documentation
  @param data see 'wickr_fingerprint' property documentation
  @return a newly allocated fingerprint that takes ownership of the passed inputs
  */
-wickr_fingerprint_t *wickr_fingerprint_create(wickr_buffer_t *data);
+wickr_fingerprint_t *wickr_fingerprint_create(wickr_fingerprint_type type, wickr_buffer_t *data);
 
     
 /**

--- a/src/wickrcrypto/src/fingerprint.c
+++ b/src/wickrcrypto/src/fingerprint.c
@@ -182,7 +182,11 @@ static wickr_buffer_t *__wickr_fingerprint_encode_for_output_mode(const wickr_fi
     wickr_buffer_t *encoded_fingerprint_data = enc_func(fingerprint->data);
     
     if (output_mode == FINGERPRINT_OUTPUT_SHORT) {
-        encoded_fingerprint_data->length = encoded_fingerprint_data->length / 2;
+        size_t short_length = encoded_fingerprint_data->length / 2;
+        
+        /* Replace the byte at index short_length with a null byte to make sure string encoding is proper */
+        encoded_fingerprint_data->bytes[short_length] = '\0';
+        encoded_fingerprint_data->length = short_length;
     }
         
     return encoded_fingerprint_data;

--- a/src/wickrcrypto/src/fingerprint.c
+++ b/src/wickrcrypto/src/fingerprint.c
@@ -17,7 +17,7 @@ static wickr_fingerprint_t *__wickr_fingerprint_sha512_create(wickr_crypto_engin
         return NULL;
     }
     
-    wickr_fingerprint_t *fingerprint = wickr_fingerprint_create(fingerprint_data);
+    wickr_fingerprint_t *fingerprint = wickr_fingerprint_create(WICKR_FINGERPRINT_TYPE_SHA512, fingerprint_data);
     
     if (!fingerprint) {
         wickr_buffer_destroy(&fingerprint_data);
@@ -50,7 +50,7 @@ static wickr_fingerprint_t *__wickr_fingerprint_sha512_combine(wickr_crypto_engi
         return NULL;
     }
     
-    if (f1->data->length != f2->data->length) {
+    if (f1->data->length != f2->data->length || f1->type != f2->type) {
         return NULL;
     }
     
@@ -119,7 +119,7 @@ wickr_fingerprint_t *wickr_fingerprint_gen_bilateral(wickr_crypto_engine_t engin
     }
 }
 
-wickr_fingerprint_t *wickr_fingerprint_create(wickr_buffer_t *data)
+wickr_fingerprint_t *wickr_fingerprint_create(wickr_fingerprint_type type, wickr_buffer_t *data)
 {
     if (!data) {
         return NULL;
@@ -132,6 +132,7 @@ wickr_fingerprint_t *wickr_fingerprint_create(wickr_buffer_t *data)
     }
     
     fingerprint->data = data;
+    fingerprint->type = type;
     
     return fingerprint;
 }
@@ -148,7 +149,7 @@ wickr_fingerprint_t *wickr_fingerprint_copy(const wickr_fingerprint_t *fingerpri
         return NULL;
     }
     
-    wickr_fingerprint_t *copy = wickr_fingerprint_create(data_copy);
+    wickr_fingerprint_t *copy = wickr_fingerprint_create(fingerprint->type, data_copy);
     
     if (!copy) {
         wickr_buffer_destroy(&data_copy);


### PR DESCRIPTION
* Add `type` property to fingerprint so it's calculation type can be easily inferred at runtime
* Fixed null termination on short fingerprint encodings

Fixes #107 
Fixes #105 