### PR TITLE
Always use internal node js openssl to resolve run time problems

### DIFF
--- a/node_install.sh
+++ b/node_install.sh
@@ -1,3 +1,4 @@
+git submodule update --init
 mkdir -p node/build
 cd node/build
 cmake -DBUILD_NODE=ON -DCMAKE_INSTALL_LIBDIR='lib' -DCMAKE_POSITION_INDEPENDENT_CODE=true -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../ ../../ 
@@ -5,3 +6,4 @@ make
 make install
 
 cd ..
+rm -rf build

--- a/src/wickrcrypto/swig/node/CMakeLists.txt
+++ b/src/wickrcrypto/swig/node/CMakeLists.txt
@@ -19,9 +19,7 @@ if (APPLE AND NOT IOS)
         TARGET wickrcryptoswig 
         POST_BUILD 
         COMMAND install_name_tool -id "@rpath/wickrcrypto.node" $<TARGET_FILE:wickrcryptoswig>
-        COMMAND install_name_tool -change "${OPENSSL_CRYPTO_SHARED}" "@rpath/libcrypto.1.1.dylib" $<TARGET_FILE:wickrcryptoswig>
         COMMAND install_name_tool -add_rpath "@loader_path" $<TARGET_FILE:wickrcryptoswig>
-        COMMAND install_name_tool -id "@rpath/libcrypto.1.1.dylib" ${OPENSSL_CRYPTO_SHARED}
     )
 endif ()
 

--- a/third-party/openssl/CMakeLists.txt
+++ b/third-party/openssl/CMakeLists.txt
@@ -1,6 +1,9 @@
-
 option(FIPS "Build OpenSSL in fips mode" OFF)
 option(OPENSSL_102 "Use OpenSSL 1.0.2 instead of OpenSSL 1.1.1" OFF)
+
+if (BUILD_NODE AND (FIPS OR BUILD_OPENSSL))
+    message(WARNING "Node exports all of the openssl symbols, we are forced to use their versions")
+endif ()
 
 # FIPS is only supported on OPENSSL 1.0.2
 if (FIPS)
@@ -14,13 +17,21 @@ if (OPENSSL_102 AND NOT BUILD_OPENSSL)
 endif ()
 
 if (NOT BUILD_OPENSSL)
-    include(FindOpenSSL)
 
-    if (NOT OPENSSL_FOUND OR OPENSSL_INCLUDE_DIR STREQUAL "OPENSSL_INCLUDE_DIR-NOTFOUND")
-        if (OPENSSL_AUTO_BUILD)
-            set(BUILD_OPENSSL TRUE)
-        else ()
-            Message(FATAL_ERROR "OpenSSL was not found")
+    if (BUILD_NODE)
+        include(FindNode)
+        nodejs_init()
+        message(STATUS "Using NodeJS OpenSSL: ${NODEJS_INCLUDE_DIRS}")
+        set(OPENSSL_INCLUDE_DIR "${NODEJS_INCLUDE_DIRS}" CACHE INTERNAL "OpenSSL NodeJS Headers")
+    else ()
+        include(FindOpenSSL)
+
+        if (NOT OPENSSL_FOUND OR OPENSSL_INCLUDE_DIR STREQUAL "OPENSSL_INCLUDE_DIR-NOTFOUND")
+            if (OPENSSL_AUTO_BUILD)
+                set(BUILD_OPENSSL TRUE)
+            else ()
+                Message(FATAL_ERROR "OpenSSL was not found")
+            endif ()
         endif ()
     endif ()
 endif ()
@@ -31,7 +42,13 @@ else ()
     add_subdirectory(1.1.1)
 endif ()
 
+execute_process (
+    COMMAND bash -c "cat ${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h | grep \"OPENSSL_VERSION_TEXT\""
+    OUTPUT_VARIABLE OPENSSL_VERSION
+)
+
 Message(STATUS "Using OpenSSL: ${OPENSSL_ROOT_DIR}")
+Message(STATUS "OpenSSL version: ${OPENSSL_VERSION}")
 Message(STATUS "OpenSSL include: ${OPENSSL_INCLUDE_DIR}")
 Message(STATUS "OpenSSL libraries: ${OPENSSL_LIBRARIES}")
 Message(STATUS "OpenSSL libcrypto: ${OPENSSL_CRYPTO_LIBRARY}")


### PR DESCRIPTION
NodeJS exports all OpenSSL symbols. They also provide the headers they used as part of the add-on build process. We are somewhat forced to use their symbols instead of anything build internal to us due to clashing at runtime

Fixes #120 
Fixes #121 