### PR TITLE
Added two new functions to the crypto library

### DIFF
--- a/src/wickrcrypto/include/wickrcrypto/crypto_engine.h
+++ b/src/wickrcrypto/include/wickrcrypto/crypto_engine.h
@@ -143,6 +143,39 @@ struct wickr_crypto_engine {
     /**
      @ingroup wickr_crypto_engine
      
+     Encrypt an open file
+     
+     @param fin read data to be encrypted from this FILE pointer
+     @param key the key to use for decryption
+     @param fout write encrypted data to this FILE pointer
+     @param only_auth_ciphers if true, only authenticated ciphers may be used for decryption
+     @return true if the decryption operation succeeds
+     
+     */
+    bool (*wickr_crypto_engine_encrypt_ofile)(FILE *fin,
+                                             const wickr_cipher_key_t *key,
+                                             FILE *fout);
+    
+    /**
+     @ingroup wickr_crypto_engine
+     
+     Decrypt an open file
+     
+     @param fin read encrypted data from this FILE pointer
+     @param key the key to use for decryption
+     @param fout write decrypted data to this FILE pointer
+     @param only_auth_ciphers if true, only authenticated ciphers may be used for decryption
+     @return true if the decryption operation succeeds
+     
+     */
+    bool (*wickr_crypto_engine_decrypt_ofile)(FILE *fin,
+                                             const wickr_cipher_key_t *key,
+                                             FILE *fout,
+                                             bool only_auth_ciphers);
+
+    /**
+     @ingroup wickr_crypto_engine
+     
      Calculate a hash of a buffer using an optional salt value
      
      @param buffer the buffer to hash

--- a/src/wickrcrypto/src/crypto_engine.c
+++ b/src/wickrcrypto/src/crypto_engine.c
@@ -25,6 +25,8 @@ const wickr_crypto_engine_t wickr_crypto_engine_get_default()
         openssl_aes256_decrypt,
         openssl_aes256_file_encrypt,
         openssl_aes256_file_decrypt,
+        openssl_encrypt_file,
+        openssl_decrypt_file,
         openssl_sha2,
         openssl_sha2_file,
         openssl_ec_rand_key,


### PR DESCRIPTION
Added two new functions to the crypto library
bool wickr_crypto_engine_encrypt_ofile(FILE *fin, const wickr_cipher_key_t *key, FILE *fout);
bool wickr_crypto_engine_decrypt_ofile(FILE *fin, const wickr_cipher_key_t *key, FILE *fout, bool only_auth_ciphers);

These functions already exist inside the library. This addition would make them publicly available via wickr_crypto_engine.