### PR TITLE
Fix typo and document BUILD_TESTS build config option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -234,6 +234,7 @@ cmake -DCMAKE_TOOLCHAIN_FILE=../Toolchain-iOS.cmake \
 | CMAKE_ANDROID_NDK | The location of the root directory of an NDK installation | Android |
 | IOS_PLATFORM | Set to OS for armv7,armv7s,arm64 builds or SIMULATOR for x86,x86_64 builds | iOS |
 | IOS_DEPLOYMENT_TARGET | The minimum target for the iOS build (9.0+ Recomended) | iOS |
+| BUILD_TESTS | Tells CMake to buid tests (off by default) | All |
 
 ## Building, Installing, and Testing
 
@@ -249,7 +250,7 @@ To install the library to the configured install prefix
 make install
 ``` 
 
-To run the bundled test target (macOS, Windows, Linux)
+To run the bundled test target (macOS, Windows, Linux). Requires `-DBUILD_TESTS=ON` when configuring build.
 
 ```
 make test

--- a/src/wickrcrypto/src/openssl_suite.c
+++ b/src/wickrcrypto/src/openssl_suite.c
@@ -565,7 +565,7 @@ wickr_buffer_t *openssl_aes256_decrypt(const wickr_cipher_result_t *cipher_resul
         }
     }
     
-    /* Re-Initialize the context with proper values to prepare for encryption */
+    /* Re-Initialize the context with proper values to prepare for decryption */
     if (1 != EVP_DecryptInit_ex(ctx, NULL, NULL, key->key_data->bytes, cipher_result->iv->bytes)) {
         goto process_error;
     }


### PR DESCRIPTION
#### Description of changes

Had to use `-DBUILD_TESTS=ON` when configuring the build to be able to execute test suite.

Also came across a typo. 

#### Testing

No code was harmed in this PR.