### PR TITLE
Support older versions of docker on linux

### DIFF
--- a/build_android_docker.sh
+++ b/build_android_docker.sh
@@ -8,9 +8,14 @@ BUILD_COMMAND="FIPS=${FIPS} ./build_android_fat.sh $*"
 
 echo "Building android using distro: $DISTRO and command $BUILD_COMMAND"
 
-docker buildx build --platform linux/amd64 -t crypto-android -f docker/android/Dockerfile .
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    BUILDX_COMMAND="buildx"
+    PLATFORM_FLAG="--platform linux/amd64"
+fi
 
-docker run --platform linux/amd64 \
+docker ${BUILDX_COMMAND} build ${PLATFORM_FLAG} -t crypto-android -f docker/android/Dockerfile .
+
+docker run ${PLATFORM_FLAG} \
     -e ARTIFACTORY_URL=${ARTIFACTORY_URL} \
     -e ARTIFACTORY_USER=${ARTIFACTORY_USER} \
     -e ARTIFACTORY_PASS=${ARTIFACTORY_PASS} \


### PR DESCRIPTION
Docker android build would not work on older linux machines due to the use of buildx and platform flags being in us


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
