### PR TITLE
Always use random local storage keys for clients

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(WickrCryptoC)
 
 set(VERSION_MAJOR 1)
 set(VERSION_MINOR 18)
-set(VERSION_PATCH 3)
+set(VERSION_PATCH 4)
 
 include(GNUInstallDirs)
 

--- a/src/wickrcrypto/src/root_keys.c
+++ b/src/wickrcrypto/src/root_keys.c
@@ -195,35 +195,28 @@ wickr_cipher_result_t *wickr_root_keys_export(const wickr_root_keys_t *keys, con
     return cipher_result;
 }
 
+/* dev_info is no longer used but we keep it here to avoid breaking the api */
 wickr_storage_keys_t *wickr_root_keys_localize(const wickr_root_keys_t *keys, const wickr_crypto_engine_t *engine, const wickr_dev_info_t *dev_info)
 {
     if (!keys || !dev_info) {
         return NULL;
     }
+
+    /* Local storage keys are always random */
+    wickr_cipher_key_t *local_dev_storage_key = engine->wickr_crypto_engine_cipher_key_random(CIPHER_AES256_GCM);
+
+    if (!local_dev_storage_key) {
+        return NULL;
+    }
     
-    /* Root storage is the same on every device */
+    /* Remove storage keys is the same on every device */
     wickr_cipher_key_t *rsr_copy = wickr_cipher_key_copy(keys->remote_storage_root);
     
     if (!rsr_copy) {
+        wickr_cipher_key_destroy(&local_dev_storage_key);
         return NULL;
     }
-    
-    /* Create our local storage key by taking a hash of the node_storage_root with the system_salt as the salt */
-    wickr_buffer_t *local_dev_storage_key_material = engine->wickr_crypto_engine_digest(keys->node_storage_root->key_data, dev_info->system_salt, DIGEST_SHA_256);
-    
-    if (!local_dev_storage_key_material) {
-        wickr_cipher_key_destroy(&rsr_copy);
-        return NULL;
-    }
-    
-    wickr_cipher_key_t *local_dev_storage_key = wickr_cipher_key_create(keys->node_storage_root->cipher, local_dev_storage_key_material);
-    
-    if (!local_dev_storage_key) {
-        wickr_cipher_key_destroy(&rsr_copy);
-        wickr_buffer_destroy_zero(&local_dev_storage_key_material);
-        return NULL;
-    }
-    
+        
     wickr_storage_keys_t *storage_keys = wickr_storage_keys_create(local_dev_storage_key, rsr_copy);
     
     if (!storage_keys) {

--- a/src/wickrcrypto/src/root_keys.c
+++ b/src/wickrcrypto/src/root_keys.c
@@ -209,14 +209,13 @@ wickr_storage_keys_t *wickr_root_keys_localize(const wickr_root_keys_t *keys, co
         return NULL;
     }
     
-    /* Remove storage keys is the same on every device */
+    /* Remote storage key is the same on every device */
     wickr_cipher_key_t *rsr_copy = wickr_cipher_key_copy(keys->remote_storage_root);
     
     if (!rsr_copy) {
         wickr_cipher_key_destroy(&local_dev_storage_key);
         return NULL;
     }
-        
     wickr_storage_keys_t *storage_keys = wickr_storage_keys_create(local_dev_storage_key, rsr_copy);
     
     if (!storage_keys) {


### PR DESCRIPTION
We no longer want to have deterministic storage keys based on a device secret. Replacing with a randomly generated key at client registration time.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
