### PR TITLE
fix: correct bug in base32 decode function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(WickrCryptoC)
 
 set(VERSION_MAJOR 1)
 set(VERSION_MINOR 18)
-set(VERSION_PATCH 6)
+set(VERSION_PATCH 7)
 
 include(GNUInstallDirs)
 

--- a/src/wickrcrypto/src/b32.c
+++ b/src/wickrcrypto/src/b32.c
@@ -262,13 +262,23 @@ wickr_buffer_t *base32_decode(const wickr_buffer_t *buffer)
         wickr_buffer_destroy(&unmapped);
         return NULL;
     }
-    
-    wickr_buffer_t *decoded = wickr_buffer_create_empty_zero(__base32_decode_length(unmapped->length) + 1);
-    decoded->length = decoded->length - 1;
-    
-    if (!decoded) {
+
+    size_t decode_length = __base32_decode_length(unmapped->length);
+
+    if (decode_length == 0) {
+        wickr_buffer_destroy(&unmapped);
         return NULL;
     }
+    
+    wickr_buffer_t *decoded = wickr_buffer_create_empty_zero(decode_length + 1);
+
+
+    if (!decoded) {
+        wickr_buffer_destroy(&unmapped);
+        return NULL;
+    }
+
+    decoded->length = decoded->length - 1;
     
     if (!__base32_decode_base32(unmapped->bytes, unmapped->length, decoded->bytes)) {
         wickr_buffer_destroy(&decoded);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Correct logical error in base32 decode function that would cause a crash or memory leak when decoding fails due to not having enough memory

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
