### PR TITLE
Update cipher.c to guard against malformed wickr_buffer_t

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(WickrCryptoC)
 
 set(VERSION_MAJOR 1)
 set(VERSION_MINOR 19)
-set(VERSION_PATCH 0)
+set(VERSION_PATCH 1)
 
 include(GNUInstallDirs)
 

--- a/src/wickrcrypto/src/cipher.c
+++ b/src/wickrcrypto/src/cipher.c
@@ -110,7 +110,7 @@ wickr_buffer_t *wickr_cipher_result_serialize(const wickr_cipher_result_t *resul
 
 wickr_cipher_result_t *wickr_cipher_result_from_buffer(const wickr_buffer_t *buffer)
 {
-    if (!buffer) {
+    if (!buffer || !buffer->bytes || buffer->length == 0) {
         return NULL;
     }
     


### PR DESCRIPTION
**Root Cause:** wickr_cipher_result_from_buffer() checks if the buffer pointer itself is NULL, but doesn't check if buffer->length == 0 or buffer->bytes == NULL. When protobuf-c unpacks an empty bytes field, it sets .data = NULL and .len = 0. The function then accesses buffer->bytes[0] — dereferencing NULL.

**Fix Strategy:** Add an early return of NULL when buffer->length == 0 or buffer->bytes == NULL, which will naturally propagate as ERROR_CORRUPT_PACKET through the existing error handling in protocol.c.
