### PR TITLE
fix: use wickr_buffer_destroy_zero for sensitive data

### DIFF
--- a/src/wickrcrypto/src/key_exchange.c
+++ b/src/wickrcrypto/src/key_exchange.c
@@ -458,7 +458,7 @@ wickr_key_exchange_set_t *wickr_key_exchange_set_create_from_cipher(const wickr_
     }
     
     wickr_key_exchange_set_t *deserialized_exchange = wickr_key_exchange_set_create_from_buffer(engine, decrypted_exchange);
-    wickr_buffer_destroy(&decrypted_exchange);
+    wickr_buffer_destroy_zero(&decrypted_exchange);
     
     return deserialized_exchange;
 }

--- a/src/wickrcrypto/src/openssl_suite.c
+++ b/src/wickrcrypto/src/openssl_suite.c
@@ -596,7 +596,7 @@ wickr_buffer_t *openssl_aes256_decrypt(const wickr_cipher_result_t *cipher_resul
     
 process_error:
     if (output_buffer) {
-        wickr_buffer_destroy(&output_buffer);
+        wickr_buffer_destroy_zero(&output_buffer);
     }
     if (ctx) {
         EVP_CIPHER_CTX_free(ctx);

--- a/src/wickrcrypto/src/openssl_suite.c
+++ b/src/wickrcrypto/src/openssl_suite.c
@@ -163,7 +163,7 @@ static wickr_buffer_t *__openssl_ec_pri_key_to_buffer(EC_KEY *key)
     
     uint8_t *bytes = pri_key_data->bytes;
     if (!i2d_ECPrivateKey(key, &bytes)) {
-        wickr_buffer_destroy(&pri_key_data);
+        wickr_buffer_destroy_zero(&pri_key_data);
         return NULL;
     }
     
@@ -756,7 +756,7 @@ wickr_ec_key_t *openssl_ec_rand_key(wickr_ec_curve_t curve)
     
     if (!pub_key_buffer) {
         EC_KEY_free(new_key);
-        wickr_buffer_destroy(&pri_key_buffer);
+        wickr_buffer_destroy_zero(&pri_key_buffer);
         return NULL;
     }
     
@@ -765,7 +765,7 @@ wickr_ec_key_t *openssl_ec_rand_key(wickr_ec_curve_t curve)
     wickr_ec_key_t *new_ec_key = wickr_ec_key_create(curve, pub_key_buffer, pri_key_buffer);
     
     if (!new_ec_key) {
-        wickr_buffer_destroy(&pri_key_buffer);
+        wickr_buffer_destroy_zero(&pri_key_buffer);
         wickr_buffer_destroy(&pub_key_buffer);
     }
     
@@ -1566,14 +1566,14 @@ wickr_ecdsa_result_t *openssl_ecdsa_from_raw(const wickr_ec_curve_t curve, const
         EC_KEY_free(ec_key);
         
         if (!pub_data) {
-            wickr_buffer_destroy(&pri_data);
+            wickr_buffer_destroy_zero(&pri_data);
             return NULL;
         }
         
         wickr_ec_key_t *converted_key = wickr_ec_key_create(curve, pub_data, pri_data);
         
         if (!converted_key) {
-            wickr_buffer_destroy(&pri_data);
+            wickr_buffer_destroy_zero(&pri_data);
             wickr_buffer_destroy(&pub_data);
         }
         

--- a/src/wickrcrypto/src/stream_ctx.c
+++ b/src/wickrcrypto/src/stream_ctx.c
@@ -108,15 +108,15 @@ static wickr_stream_key_t *__wickr_stream_key_create_with_evo_buffer(wickr_strea
     wickr_buffer_t *new_evo_key = wickr_buffer_copy_section(evo_buffer, DIGEST_SHA_512.size / 2, DIGEST_SHA_512.size / 2);
     
     if (!new_evo_key) {
-        wickr_buffer_destroy(&new_crypto_key);
+        wickr_buffer_destroy_zero(&new_crypto_key);
         return NULL;
     }
     
     wickr_cipher_key_t *cipher_key = wickr_cipher_key_create(old_key->cipher_key->cipher, new_crypto_key);
     
     if (!cipher_key) {
-        wickr_buffer_destroy(&new_crypto_key);
-        wickr_buffer_destroy(&new_evo_key);
+        wickr_buffer_destroy_zero(&new_crypto_key);
+        wickr_buffer_destroy_zero(&new_evo_key);
         return NULL;
     }
     
@@ -124,7 +124,7 @@ static wickr_stream_key_t *__wickr_stream_key_create_with_evo_buffer(wickr_strea
     
     if (!new_key) {
         wickr_cipher_key_destroy(&cipher_key);
-        wickr_buffer_destroy(&new_evo_key);
+        wickr_buffer_destroy_zero(&new_evo_key);
         return NULL;
     }
     
@@ -167,7 +167,7 @@ static bool __wickr_stream_ctx_evolove_key_material(wickr_stream_ctx_t *encoder,
         
         wickr_stream_key_t *new_key = __wickr_stream_key_create_with_evo_buffer(curr_key, evo_buffer);
         wickr_stream_key_destroy(&curr_key);
-        wickr_buffer_destroy(&evo_buffer);
+        wickr_buffer_destroy_zero(&evo_buffer);
 
         if (!new_key) {
             return false;

--- a/src/wickrcrypto/src/stream_key.c
+++ b/src/wickrcrypto/src/stream_key.c
@@ -55,7 +55,7 @@ wickr_stream_key_t *wickr_stream_key_create_rand(const wickr_crypto_engine_t eng
     
     if (!stream_key) {
         wickr_cipher_key_destroy(&cipher_key);
-        wickr_buffer_destroy(&evo_key);
+        wickr_buffer_destroy_zero(&evo_key);
     }
     
     return stream_key;
@@ -84,7 +84,7 @@ wickr_stream_key_t *wickr_stream_key_copy(const wickr_stream_key_t *stream_key)
     
     if (stream_key->user_data && !user_data_copy) {
         wickr_cipher_key_destroy(&key_copy);
-        wickr_buffer_destroy(&evo_key_copy);
+        wickr_buffer_destroy_zero(&evo_key_copy);
         return NULL;
     }
     
@@ -95,7 +95,7 @@ wickr_stream_key_t *wickr_stream_key_copy(const wickr_stream_key_t *stream_key)
     
     if (!stream_key_copy) {
         wickr_cipher_key_destroy(&key_copy);
-        wickr_buffer_destroy(&evo_key_copy);
+        wickr_buffer_destroy_zero(&evo_key_copy);
         wickr_buffer_destroy(&user_data_copy);
     }
     

--- a/src/wickrcrypto/src/stream_key_priv.c
+++ b/src/wickrcrypto/src/stream_key_priv.c
@@ -34,11 +34,11 @@ Wickr__Proto__StreamKey *wickr_stream_key_to_proto(const wickr_stream_key_t *key
     }
     
     if (!wickr_buffer_to_protobytes(&proto->cipher_key, key_buffer)) {
-        wickr_buffer_destroy(&key_buffer);
+        wickr_buffer_destroy_zero(&key_buffer);
         return NULL;
     }
     
-    wickr_buffer_destroy(&key_buffer);
+    wickr_buffer_destroy_zero(&key_buffer);
 
     proto->evolution_key.data = key->evolution_key->bytes;
     proto->evolution_key.len = key->evolution_key->length;
@@ -70,7 +70,7 @@ wickr_stream_key_t *wickr_stream_key_create_from_proto(const Wickr__Proto__Strea
     }
     
     wickr_cipher_key_t *cipher_key = wickr_cipher_key_from_buffer(key_buffer);
-    wickr_buffer_destroy(&key_buffer);
+    wickr_buffer_destroy_zero(&key_buffer);
     
     if (!cipher_key) {
         return NULL;
@@ -90,7 +90,7 @@ wickr_stream_key_t *wickr_stream_key_create_from_proto(const Wickr__Proto__Strea
         
         if (!user_data) {
             wickr_cipher_key_destroy(&cipher_key);
-            wickr_buffer_destroy(&evo_key);
+            wickr_buffer_destroy_zero(&evo_key);
             return NULL;
         }
     }
@@ -99,7 +99,7 @@ wickr_stream_key_t *wickr_stream_key_create_from_proto(const Wickr__Proto__Strea
     
     if (!stream_key) {
         wickr_cipher_key_destroy(&cipher_key);
-        wickr_buffer_destroy(&evo_key);
+        wickr_buffer_destroy_zero(&evo_key);
         return NULL;
     }
     

--- a/src/wickrcrypto/src/transport_handshake.c
+++ b/src/wickrcrypto/src/transport_handshake.c
@@ -483,7 +483,7 @@ static void __wickr_transport_handshake_process_response(wickr_transport_handsha
     }
     
     Wickr__Proto__HandshakeV1ResponseData *response_data = wickr_proto_handshake_response_data_from_buffer(response_buffer);
-    wickr_buffer_destroy(&response_buffer);
+    wickr_buffer_destroy_zero(&response_buffer);
     
     if (!response_data || !response_data->root_key) {
         handshake->status = TRANSPORT_HANDSHAKE_STATUS_FAILED;

--- a/src/wickrcrypto/src/transport_root_key.c
+++ b/src/wickrcrypto/src/transport_root_key.c
@@ -20,7 +20,7 @@ wickr_transport_root_key_t *wickr_transport_root_key_create_random(const wickr_c
     wickr_transport_root_key_t *root_key = wickr_transport_root_key_create(secret, cipher, packets_per_evo_send, packets_per_evo_recv);
     
     if (!root_key) {
-        wickr_buffer_destroy(&secret);
+        wickr_buffer_destroy_zero(&secret);
     }
     
     return root_key;
@@ -67,7 +67,7 @@ wickr_transport_root_key_t *wickr_transport_root_key_copy(const wickr_transport_
                                                                                 root_key->packets_per_evo_recv);
     
     if (!root_key_copy) {
-        wickr_buffer_destroy(&secret_copy);
+        wickr_buffer_destroy_zero(&secret_copy);
     }
     
     return root_key_copy;
@@ -79,7 +79,7 @@ void wickr_transport_root_key_destroy(wickr_transport_root_key_t **root_key)
         return;
     }
     
-    wickr_buffer_destroy(&(*root_key)->secret);
+    wickr_buffer_destroy_zero(&(*root_key)->secret);
     wickr_free(*root_key);
     *root_key = NULL;
 }
@@ -105,7 +105,7 @@ wickr_stream_key_t *wickr_transport_root_key_to_stream_key(const wickr_transport
     wickr_cipher_key_t *cipher_key = wickr_cipher_key_create(root_key->cipher, cipher_key_data);
     
     if (!cipher_key) {
-        wickr_buffer_destroy(&cipher_key_data);
+        wickr_buffer_destroy_zero(&cipher_key_data);
         return NULL;
     }
     
@@ -122,7 +122,7 @@ wickr_stream_key_t *wickr_transport_root_key_to_stream_key(const wickr_transport
     
     if (!stream_key) {
         wickr_cipher_key_destroy(&cipher_key);
-        wickr_buffer_destroy(&evo_key);
+        wickr_buffer_destroy_zero(&evo_key);
     }
     
     return stream_key;

--- a/src/wickrcrypto/src/transport_root_key_priv.c
+++ b/src/wickrcrypto/src/transport_root_key_priv.c
@@ -51,7 +51,7 @@ wickr_transport_root_key_t *wickr_transport_root_key_from_proto(const Wickr__Pro
     const wickr_cipher_t *cipher = wickr_cipher_find(root_key_proto->cipher_id);
     
     if (!cipher) {
-        wickr_buffer_destroy(&secret_buffer);
+        wickr_buffer_destroy_zero(&secret_buffer);
         return NULL;
     }
     
@@ -60,7 +60,7 @@ wickr_transport_root_key_t *wickr_transport_root_key_from_proto(const Wickr__Pro
                                                                            root_key_proto->packets_per_evo_recv);
     
     if (!root_key) {
-        wickr_buffer_destroy(&secret_buffer);
+        wickr_buffer_destroy_zero(&secret_buffer);
     }
     
     return root_key;

--- a/src/wickrcrypto/src/wickr_ctx.c
+++ b/src/wickrcrypto/src/wickr_ctx.c
@@ -112,7 +112,7 @@ wickr_ctx_gen_result_t *wickr_ctx_gen_with_passphrase(const wickr_crypto_engine_
     }
     
     wickr_cipher_key_t *recovery_key = wickr_cipher_key_from_buffer(decrypted_recovery_bytes);
-    wickr_buffer_destroy(&decrypted_recovery_bytes);
+    wickr_buffer_destroy_zero(&decrypted_recovery_bytes);
 
     if (!recovery_key) {
         return NULL;
@@ -305,7 +305,7 @@ wickr_cipher_key_t *wickr_ctx_gen_import_recovery_key_passphrase(const wickr_cry
     }
     
     wickr_cipher_key_t *recovery_key = wickr_cipher_key_from_buffer(decoded_recovery);
-    wickr_buffer_destroy(&decoded_recovery);
+    wickr_buffer_destroy_zero(&decoded_recovery);
     
     return recovery_key;
 }
@@ -624,7 +624,7 @@ wickr_ctx_t *wickr_ctx_import(const wickr_crypto_engine_t engine,
     }
     
     wickr_ctx_t *ctx = wickr_ctx_create_from_buffer(engine, dev_info, decoded_ctx);
-    wickr_buffer_destroy(&decoded_ctx);
+    wickr_buffer_destroy_zero(&decoded_ctx);
     
     return ctx;
 }
@@ -661,7 +661,7 @@ wickr_storage_keys_t *wickr_ctx_import_storage_keys(const wickr_crypto_engine_t 
     }
     
     wickr_storage_keys_t *storage_keys = wickr_storage_keys_create_from_buffer(decoded_serialized_keys);
-    wickr_buffer_destroy(&decoded_serialized_keys);
+    wickr_buffer_destroy_zero(&decoded_serialized_keys);
     
     return storage_keys;
 }

--- a/third-party/openssl/aws-lc/CMakeLists.txt
+++ b/third-party/openssl/aws-lc/CMakeLists.txt
@@ -3,7 +3,7 @@ include(ExternalProject)
 set(AWS_LC_BUILD_OPTS -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DFIPS=${FIPS} -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR})
 
 if(APPLE)
-    set(AWS_LC_WARNING_FLAGS "-Wno-error=cast-function-type-mismatch -Wno-error=unknown-warning-option")
+    set(AWS_LC_WARNING_FLAGS "-Wno-error=cast-function-type-mismatch -Wno-error=unknown-warning-option -Wno-error=unterminated-string-initialization")
     set(AWS_LC_BUILD_OPTS ${AWS_LC_BUILD_OPTS} -DCMAKE_C_FLAGS=${AWS_LC_WARNING_FLAGS})
 
     # Resolve sysroot explicitly — CMake doesn't auto-populate CMAKE_OSX_SYSROOT


### PR DESCRIPTION
Also:
* Fix iOS build by suppressing the unterminated-string-initialization triggered by AWS LC

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
